### PR TITLE
Timezone Fix

### DIFF
--- a/app/models/assignment_plan.rb
+++ b/app/models/assignment_plan.rb
@@ -9,17 +9,102 @@ class AssignmentPlan < ActiveRecord::Base
   # has_many :assignment_exercises, :dependent => :destroy, :order => :number
   
   before_destroy :destroyable?
+
+
+  ##
+  ## Start and end times
+  ##
+
+  attr_accessible :starts_at, :ends_at
+  attr_accessor :starts_at_string, :ends_at_string # virtual
+  attr_accessible :starts_at_string, :ends_at_string
   
-  before_validation :initialize_start_end, :on => :create
+  before_validation :initialize_starts_ends_at # will abort validations if returns false
+  validates :starts_at, :ends_at, :presence => true
+  validates :ends_at, :date => {:after => :starts_at, :message => "End time must be after start time"}, :if => :starts_ends_at_present?
+  validate :starts_ends_at_in_bounds
+
+  # def starts_at_string
+  #   if starts_at.present?
+  #     @starts_at_string = TimeUtils.time_to_time_in_zone_string(starts_at, learning_plan.klass.time_zone)
+  #   end
+  #   @starts_at_string
+  # end
+  # def ends_at_string
+  #   if ends_at.present?
+  #     @ends_at_string = TimeUtils.time_to_time_in_zone_string(ends_at, learning_plan.klass.time_zone)
+  #   end
+  #   @ends_at_string
+  # end
+  
+  def starts_ends_at_present?
+    starts_at.present? && ends_at.present?
+  end
+
+  def initialize_starts_ends_at
+    if starts_at_string.present? || ends_at_string.present? 
+      # construct from starts_at/ends_at strings
+      initialize_starts_at_from_string
+      initialize_ends_at_from_string
+    else
+      # constructing default using other AssignmentPlans in Klass
+      initialize_starts_ends_at_default
+    end
+    errors.none?
+  end
+
+  def initialize_starts_ends_at_default
+    return if !starts_at.nil? && !ends_at.nil?
+    
+    latest_end = peers.blank? ? nil : peers.collect{|p| p.ends_at}.max
+
+    self.starts_at = latest_end.nil? ? learning_plan.klass.start_date : latest_end
+    self.ends_at = self.starts_at + 7.days
+
+    if self.ends_at > learning_plan.klass.end_date
+      self.ends_at = learning_plan.klass.end_date
+      self.starts_at = self.ends_at - 7.days
+      
+      if self.starts_at < learning_plan.klass.start_date
+        self.starts_at = learning_plan.klass.start_date
+      end
+    end
+  end
+
+  def initialize_starts_at_from_string
+    self.starts_at = nil
+    if starts_at_string.present?
+      self.starts_at = TimeUtils.time_and_zone_strings_to_utc_time(starts_at_string, learning_plan.klass.time_zone)
+    else
+      errors.add(:starts_at, 'can\'t be blank')
+    end
+  rescue Exception => ex
+    errors.add(:starts_at_string, 'could not be parsed')
+  end
+
+  def initialize_ends_at_from_string
+    self.ends_at = nil
+    if ends_at_string.present?
+      self.ends_at = TimeUtils.time_and_zone_strings_to_utc_time(ends_at_string, learning_plan.klass.time_zone)
+    else
+      errors.add(:ends_at, 'can\'t be blank')
+    end
+  rescue Exception => ex
+    errors.add(:ends_at_string, 'could not be parsed')
+  end
+
+  def starts_ends_at_in_bounds
+    errors.add(:starts_at, "This assignment cannot start before its class starts.") if starts_at < learning_plan.klass.start_date
+    errors.add(:ends_at, "This assignment cannot end after its class ends.") if ends_at > learning_plan.klass.end_date
+  end
+
+
   
   validates :name, :presence => true, :uniqueness => {:scope => :learning_plan_id}
-  validates :starts_at, :presence => true
-  validates :ends_at, :presence => true, :date => {:after => :starts_at}
-  validate :start_and_end_in_bounds
   validates :max_num_exercises, :allow_nil => true, :numericality => { :greater_than_or_equal_to => 0 }
   
-  attr_accessible :ends_at, :introduction, :is_group_work_allowed, :is_open_book, 
-                  :is_ready, :is_test, :learning_plan_id, :name, :starts_at, :learning_plan
+  attr_accessible :introduction, :is_group_work_allowed, :is_open_book, 
+                  :is_ready, :is_test, :learning_plan_id, :name, :learning_plan
   
   scope :non_tests, where(:is_test => false)
   scope :tests, where(:is_test => true)
@@ -91,36 +176,5 @@ class AssignmentPlan < ActiveRecord::Base
   def can_be_destroyed_by?(user)
     learning_plan.can_be_updated_by?(user)
   end
-  
-protected
-
-  def initialize_start_end  
-    return if !starts_at.nil? && !ends_at.nil?
-    
-    latest_end = peers.blank? ? nil : peers.collect{|p| p.ends_at}.max
-
-    self.starts_at = latest_end.nil? ? learning_plan.klass.start_date : latest_end
-    self.ends_at = self.starts_at + 7.days
-
-    if self.ends_at > learning_plan.klass.end_date
-      self.ends_at = learning_plan.klass.end_date
-      self.starts_at = self.ends_at - 7.days
-      
-      if self.starts_at < learning_plan.klass.start_date
-        self.starts_at = learning_plan.klass.start_date
-      end
-    end
-  end
-  
-  def start_and_end_in_bounds
-    errors.add(:starts_at, "This assignment cannot start before its class starts.") \
-      if starts_at < learning_plan.klass.start_date
-        
-    errors.add(:ends_at, "This assignment cannot end after its class ends.") \
-      if ends_at > learning_plan.klass.end_date
-
-    errors.none?
-  end
-  
   
 end

--- a/app/views/assignment_plans/_assignment_plan_event.html.erb
+++ b/app/views/assignment_plans/_assignment_plan_event.html.erb
@@ -1,7 +1,7 @@
 {
   title  : '<%= assignment_plan.name %>',
-  start  : '<%= assignment_plan.starts_at.strftime("%Y-%m-%d %H:%M") %>',
-  end  : '<%= assignment_plan.ends_at.strftime("%Y-%m-%d %H:%M") %>',
+  start  : '<%= TimeUtils.time_to_time_in_zone_string(assignment_plan.starts_at, assignment_plan.learning_plan.klass.time_zone, "%Y-%m-%d %H:%M") %>',
+  end  : '<%= TimeUtils.time_to_time_in_zone_string(assignment_plan.ends_at, assignment_plan.learning_plan.klass.time_zone, "%Y-%m-%d %H:%M") %>',
   allDay : false,
   editable: true,
   ost_id : <%= assignment_plan.id %>,

--- a/app/views/learning_plans/show.html.erb
+++ b/app/views/learning_plans/show.html.erb
@@ -43,84 +43,73 @@
 
   <% content_for :javascript do %>
     <%= javascript_tag do %>
-    
-      function timeInClassZone(dd) {
-        
-        klass_minus_utc_hours = <%=
-          original_time_zone = Time.zone
-          # This is not accounting for daylight vs standard time re the incoming time
-          Time.zone = @learning_plan.klass.time_zone
-          offset = Time.zone.now.utc_offset/3600;
-          Time.zone = original_time_zone
-          offset
-        %>;
-        
-        utc_minus_local_hours = dd.getTimezoneOffset()/60;
-        local_time = dd.getTime();
-        klass_time = new Date(local_time - (utc_minus_local_hours + klass_minus_utc_hours)*60*60*1000);
-      
-      <% if Rails.env.development? %>  
-        alert (
-          "incoming time:         " + dd + "\n" +
-          "klass_minus_utc_hours: " + klass_minus_utc_hours + "\n" +
-          "utc_minus_local_hours: " + utc_minus_local_hours + "\n" +
-          "local_time:            " + local_time + "\n" +
-          "klass_time:            " + klass_time + "\n"
-        );
-      <% end %>
-        
-        return klass_time;
-      }
+
+ 	function pad_leading_zeros (num, size) {
+		var s = num + "";
+		while (s.length < size)
+		  s = "0" + s;
+		return s;
+	}
+
+	function format_event_date(calDate) {
+		s = pad_leading_zeros(calDate.getFullYear(), 4)  + "-" +
+		    pad_leading_zeros(calDate.getMonth()+1, 2)   + "-" +
+		    pad_leading_zeros(calDate.getDate(), 2)      + " " +
+			pad_leading_zeros(calDate.getHours(), 2)     + ":" +
+			pad_leading_zeros(calDate.getMinutes(), 2)   + ":" +
+			pad_leading_zeros(calDate.getSeconds(), 2);
+		return s;
+	}
   
-      function update_assignment_plan_times(id, starts_at, ends_at, revertFunc) {
-        $.ajax({
-          type: "POST",
-          url: '/assignment_plans/' + id,
-          data: { 
-                  _method:'PUT', 
-                  assignment_plan : { 
-                      starts_at: timeInClassZone(starts_at), 
-                      ends_at: timeInClassZone(ends_at) 
-                  } 
-          },
-          dataType: 'json',
-          success: function(msg) {},
-          error: function(jqXHR, textStatus, errorThrown) {
-            open_message_dialog(true, 150, 440, 'Error!', jQuery.parseJSON(jqXHR.responseText).join("<br/><br/>"));
-            revertFunc();
-          }
-        });
-      }
-      
-      $(document).ready(function() {
-        $('#calendar').fullCalendar({
-            timeFormat:  'h(:mm)t { - h(:mm)t}  ',
-            eventColor: get_os_color('blue'),
-            header: {
-              left: 'title',
-              center: 'agendaWeek,month',
-              right: 'today prev,next'
-            },
-            events: [
-              <% events = @learning_plan.assignment_plans.each_with_index do |assignment_plan, ii| %>
-                <%= (render :partial => 'assignment_plans/assignment_plan_event', 
-                           :locals => {:assignment_plan => assignment_plan}).html_safe %>
-                <%= ','.html_safe if ii != @learning_plan.assignment_plans.count - 1%>
-              <% end %>
-            ],
-            eventClick: function(calEvent, jsEvent, view) {
-              $('#calendar').fullCalendar('changeView', view.name == 'agendaWeek' ? 'month' : 'agendaWeek' )
-                            .fullCalendar('gotoDate', calEvent.start);
-            },
-            eventResize: function( event, dayDelta, minuteDelta, revertFunc, jsEvent, ui, view ) { 
-              update_assignment_plan_times(event.ost_id, event.start, event.end, revertFunc);
-            },
-            eventDrop: function(event,dayDelta,minuteDelta,allDay,revertFunc) {
-              update_assignment_plan_times(event.ost_id, event.start, event.end, revertFunc);
-            }
-        });        
-      });
-      
+	function handle_event_update(calEvent, revertFunc) {
+		 $.ajax({
+		   type: "POST",
+		   url: '/assignment_plans/' + calEvent.ost_id,
+		   data: { 
+		           _method:'PUT', 
+		           assignment_plan : { 
+		               starts_at_string: format_event_date(calEvent.start), 
+		               ends_at_string:   format_event_date(calEvent.end) 
+		           } 
+		   },
+		   dataType: 'json',
+		   success: function(msg) {},
+		   error: function(jqXHR, textStatus, errorThrown) {
+		     open_message_dialog(true, 150, 440, 'Error!', jQuery.parseJSON(jqXHR.responseText).join("<br/><br/>"));
+		     revertFunc();
+		   }
+		 });
+	}
+  
+	$(document).ready(function() {
+	  $('#calendar').fullCalendar({
+	      timeFormat:  'h(:mm)t { - h(:mm)t}  ',
+	      eventColor: get_os_color('blue'),
+	      header: {
+	        left: 'title',
+	        center: 'agendaWeek,month',
+	        right: 'today prev,next'
+	      },
+	      events: [
+	        <% events = @learning_plan.assignment_plans.each_with_index do |assignment_plan, ii| %>
+	          <%= (render :partial => 'assignment_plans/assignment_plan_event', 
+	                     :locals => {:assignment_plan => assignment_plan}).html_safe %>
+	          <%= ','.html_safe if ii != @learning_plan.assignment_plans.count - 1%>
+	        <% end %>
+	      ],
+	      eventClick: function(calEvent, jsEvent, view) {
+	        $('#calendar').fullCalendar('changeView', view.name == 'agendaWeek' ? 'month' : 'agendaWeek' )
+	                      .fullCalendar('gotoDate', calEvent.start);
+	      },
+	      eventResize: function(calEvent, dayDelta, minuteDelta, revertFunc, jsEvent, ui, view ) { 
+	        handle_event_update(calEvent, revertFunc);
+	      },
+	      eventDrop: function(calEvent,dayDelta,minuteDelta,allDay,revertFunc) {
+	        handle_event_update(calEvent, revertFunc);
+	      }
+	  });        
+	});
+         
     <% end %>
   <% end %>
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,6 +8,7 @@ require 'ost_utilities'
 require 'belongs_to_exercise'
 require 'acts_as_numberable'
 require 'enum'
+require 'time_utils'
 
 # STANDARD_DATETIME_FORMAT = "%m/%d/%Y %l:%M %p"
 STANDARD_DATETIME_FORMAT = "%b %d, %Y %l:%M %p %Z"

--- a/lib/time_utils.rb
+++ b/lib/time_utils.rb
@@ -1,0 +1,33 @@
+module TimeUtils
+  def self.time_and_zone_strings_to_utc_time(origin_time_string, origin_zone_string)
+    original_chronic_time_class = Chronic.time_class
+    origin_zone = ActiveSupport::TimeZone.new(format_zone_string(origin_zone_string))
+    raise "unable to parse origin zone string: (#{origin_zone_string})" if origin_zone.nil?
+    origin_time = Chronic.parse(origin_time_string)
+    raise "unable to parse origin time string: (#{origin_time_string})" if origin_time.nil?
+    origin_zone.local_to_utc(origin_time)
+  ensure
+    Chronic.time_class = original_chronic_time_class
+  end
+
+  def self.time_to_time_in_zone_string(time, target_zone_string, time_format_string='%Y-%m-%d %H:%M:%S')
+    target_zone = ActiveSupport::TimeZone.new(target_zone_string)
+    raise "unable to parse target zone string: #{target_zone_string}" if target_zone.nil?
+    target_zone.utc_to_local(time.utc).strftime(time_format_string)
+  end
+  
+  def self.time_to_time_string(time, time_format_string='%Y-%m-%d %H:%M:%S')
+    time.strftime(time_format_string)
+  end
+  
+  def self.zone_to_string(zone)
+    format_zone_string(zone.to_s)
+  end
+  
+  def self.format_zone_string(str)
+    if /^\(.*?\)\s+(?<rest>.*)$/ =~ str
+      str = rest
+    end
+    str
+  end
+end


### PR DESCRIPTION
This fix can be tested by running the db:scenario:full_learning_plan and dragging an assignment such that it spans Nov 4 2012 (the date that DST ends in the US).  Initially, the class's timezone is US/Central (which observes DST) and the class start/end times will match.  After dragging the assignment, change the class's timezone to US/Hawaii (which doesn't observe DST) and revisit the leaning plan.  The start and end times of the previously dragged assignment will be off by an hour, as it should be in Hawaii.

This fix also eliminates the alert popup when assignments are updated.
