### PR TITLE
Changes related to Student has_dropped?

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -445,4 +445,14 @@ module ApplicationHelper
     (form_builder.radio_button field_symbol, enum_class[enum_name]) + enum_name.to_s.humanize
   end
   
+  def student_status_string(student)
+    if student.has_dropped?
+      "DROPPED"
+    elsif student.auditing?
+      "AUDITING"
+    else
+      "REGISTERED"
+    end
+  end
+  
 end

--- a/app/models/assignment_observer.rb
+++ b/app/models/assignment_observer.rb
@@ -3,7 +3,7 @@ class AssignmentObserver < ActiveRecord::Observer
   def after_create(assignment)
     return if assignment.dry_run
     
-    assignment.cohort.students.each do |student|
+    assignment.cohort.students.active.each do |student|
       AssignmentMailer.student_created(student, assignment).deliver
     end
     

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -70,7 +70,7 @@ class Cohort < ActiveRecord::Base
       (klass.is_controlled_experiment ? Researcher.is_one?(user) : klass.is_instructor?(user)) || 
       user.is_administrator?
     when :assignments
-      klass.is_educator?(user) || klass.is_student?(user) || Researcher.is_one?(user) || user.is_administrator?
+      klass.is_educator?(user) || klass.is_active_student?(user) || Researcher.is_one?(user) || user.is_administrator?
     end
   end
   

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -167,8 +167,8 @@ protected
     cohorts = section.cohorts
     cohorts = section.klass.cohorts if cohorts.empty?
 
-    smallest_cohort_size = cohorts.collect{|c| c.students.same_kind_as(self).count}.min
-    candidate_cohorts = cohorts.select{|c| c.students.same_kind_as(self).count == smallest_cohort_size}
+    smallest_cohort_size = cohorts.collect{|c| c.students.active.same_kind_as(self).count}.min
+    candidate_cohorts = cohorts.select{|c| c.students.active.same_kind_as(self).count == smallest_cohort_size}
     
     target_cohort = candidate_cohorts.sample
     self.cohort = target_cohort

--- a/app/views/classes/show.html.erb
+++ b/app/views/classes/show.html.erb
@@ -16,7 +16,7 @@
                   drop_student_path(student), 
                   :class => "link_button",
                   :method => :put,
-                  :confirm => "Are you sure you want to drop this class?\n\nThis cannot be undone!" %>
+                  :confirm => "Are you sure you want to drop this class?\n\nThis can only be undone by an instructor!" %>
     <% else %>
       You dropped this class.
     <% end %>

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -8,7 +8,7 @@
 <p>
   <b>Students</b>
   <%= uber_list @cohort.students, nil, {:hide_trash => true, :hide_edit => true} do |entry| %>
-    <% entry.full_name(present_user) + " " + (entry.auditing? ? "(AUDITING)" : "(REGISTERED)")%>
+    <% entry.full_name(present_user) + " (" + student_status_string(entry) + ")" %>
   <% end %>
 </p>
 

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -1,11 +1,24 @@
 <%= pageHeading "Dashboard" %>
 
 
-<% if (students = present_user.students).any? %>
+<% if (students = present_user.students).active.any? %>
   <%= section "Classes I'm Taking" do %>
     
     <ul>
-    <% students.each do |student| %>
+    <% students.active.each do |student| %>
+      <% klass = student.section.klass %>
+      <li><%= link_to klass.course.name, klass %></li>    
+    <% end %>
+    </ul>
+  
+  <% end %>
+<% end %>
+
+<% if (students = present_user.students).dropped.any? %>
+  <%= section "Classes I've Dropped" do %>
+    
+    <ul>
+    <% students.dropped.each do |student| %>
       <% klass = student.section.klass %>
       <li><%= link_to klass.course.name, klass %></li>    
     <% end %>

--- a/app/views/students/edit.html.erb
+++ b/app/views/students/edit.html.erb
@@ -9,6 +9,15 @@
   <center><%= f.submit "Toggle Auditing/Fully Registered", :disable_with => "Please Wait..." %></center>
 <% end %>
 
+<% if @student.has_dropped? %>
+	<%= form_for(@student) do |f| %>
+	  <%= f.hidden_field :has_dropped, :value => false %>
+	  <center><%= f.submit "Reinstate Dropped Student ", 
+						   :confirm => "Are you sure you want to reinstate this student?\n\nThis cannot be undone by you!",
+						   :disable_with => "Please Wait..." %></center>
+	<% end %>
+<% end %>
+
 <% other_sections = @student.section.klass.sections.reject{|s| s.id == @student.section_id} %>
 
 <% if other_sections.any? %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,7 +1,5 @@
 <%= pageHeading "Student Roster, #{@klass.course.name}" %>
 
-<p>Students who have dropped out are shown in <span class="dropped_student">gray</span>.</p>
-
 <% if present_user.is_researcher? %>
   <p>Since you are a researcher, this list only includes students who have consented.</p>
 <% end %>
@@ -32,7 +30,7 @@
         </tr>
       <% end %>
       <% students.each do |student| %>
-        <tr <%= "class='dropped_student'" if student.has_dropped? %>>
+        <tr>
           <% if num_sections > 1 %>
             <td></td>
           <% end %>
@@ -40,7 +38,7 @@
           <% if present_user.is_administrator? %>
             <td><%= student.user.research_id %></td>
           <% end %>
-          <td><%= student.is_auditing ? "AUDITING" : "REGISTERED" %>
+          <td><%= student_status_string(student) %>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,7 +1,16 @@
 <%= pageHeading(@student.full_name(present_user), {:sub_heading_text => full_class_name(@student.section)}) %>
 
 <%= section "Status" do %>
-  <p><%= @student.full_name(present_user) %> is <%= @student.is_auditing ? "auditing" : "fully registered for" %> this class in the <%= @student.section.name %> section<%= " (in cohort #{@student.cohort.name})" if present_user.can_read_children?(@student.section.klass, :cohorts) %>.</p>
+
+    <p><%= @student.full_name(present_user) %> has been assigned to the <%= @student.section.name %> section<%= " (in cohort #{@student.cohort.name})" if present_user.can_read_children?(@student.section.klass, :cohorts) %>.</p>
+  <% if @student.has_dropped? %>
+    <p><%= @student.full_name(present_user) %> has dropped this class.</p>
+  <% elsif @student.registered? %>
+    <p><%= @student.full_name(present_user) %> is fully registered for this class.</p>
+  <% elsif @student.auditing? %>
+    <p><%= @student.full_name(present_user) %> is auditing this class.</p>
+  <% end%>
+
 <% end %>
 
 <% if present_user.can_read_children?(@student, :student_assignments) %>


### PR DESCRIPTION
This makes issue #43 OBE and partially addresses issues #83 (still no mailer) and #17 (views updated but not access control).

(1) added helper to format student status string for views
(2) assignment_observer only mails active students
(3) cohort assignments can only be read by active students
(4) when assigning students to cohorts, only active students are considered for cohort size
(5) changed confirmation message when student drops class to indicate that instructor can undo
(6) changed cohort show view to use student status string helper
(7) changed dashboard to separate active classes from dropped classes
(8) changed prof student edit view to allow reinstatement of dropped students
(9) changed prof student roster view to use student status string helper
(10) changed prof student show view wording to separate student section/cohort assignment from student status
