### PR TITLE
Sort student by status then by name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -445,13 +445,25 @@ module ApplicationHelper
     (form_builder.radio_button field_symbol, enum_class[enum_name]) + enum_name.to_s.humanize
   end
   
+  def student_status_string_registered
+    "REGISTERED"
+  end
+
+  def student_status_string_auditing
+    "AUDITING"
+  end
+
+  def student_status_string_dropped
+    "DROPPED"
+  end
+  
   def student_status_string(student)
     if student.has_dropped?
-      "DROPPED"
+      student_status_string_dropped
     elsif student.auditing?
-      "AUDITING"
+      student_status_string_auditing
     else
-      "REGISTERED"
+      student_status_string_registered
     end
   end
   

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -21,8 +21,9 @@
 
   <% @klass.sections.each do |section| %>
   
-    <% students = section.students.visible(present_user).std_sort(present_user) %>
-    
+    <% groups = section.students.visible(present_user).std_sort(present_user).group_by { |s| student_status_string(s) } %>
+	<% students = groups[student_status_string_registered] + groups[student_status_string_auditing] + groups[student_status_string_dropped] %>
+
     <% if students.any? %>
       <% if num_sections > 1 %>
         <tr>


### PR DESCRIPTION
This should resolve issue #85.

Students are sorted first by their registration status (first registered, then auditing, then dropped) and secondarily by Student#:std_sort (which is last name or research id depending on the user).
