### PR TITLE
patch: StudentsAssignments without associated Assignment

### DIFF
--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -19,7 +19,9 @@
   <%= section "Assignments" do %>
     <ol>
     <% @student.student_assignments.each do |student_assignment| %>
+      <% if student_assignment.assignment && student_assignment.assignment.assignment_plan %>
       <li><%= link_to student_assignment.assignment.assignment_plan.name, student_assignment %></li>
+      <% end %>
     <% end %>
     </ol>
   <% end %>


### PR DESCRIPTION
Due to what appears to be database corruption incurred during manual cleanup of an active class, some StudentAssignments no longer have associated Assignments (specifically, StudentAssignments for those Students who viewed the retracted Assignment prior to the retraction).  This is causing the Student show page to fault with the error below.

This patch simply validates the presence of the StudentAssignment's associated Assignment (as well as the Assignment's associated AssignmentPlan) and skips those which fail the validation.

As this is only a stop-gap measure, actual corrective action should still be taken (@jpslav)  to cleanup the database state.

Exception: #<NoMethodError: undefined method `assignment_plan' for nil:NilClass>

Backtrace:

app/views/students/show.html.erb:19:in `block (2 levels) in _app_views_students_show_html_erb___723338121_95942120'
app/views/students/show.html.erb:18:in`block in _app_views_students_show_html_erb___723338121_95942120'
app/helpers/application_helper.rb:46:in `block_to_partial'
app/helpers/application_helper.rb:95:in`section'
app/views/students/show.html.erb:16:in `_app_views_students_show_html_erb___723338121_95942120'
