### PR TITLE
removal of StudentAssignment lazy instantiation - phase 1

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -51,6 +51,19 @@ class Assignment < ActiveRecord::Base
     assignment_plan.active?
   end
 
+  def self.create_missing_student_assignments
+    Assignment.all.each do |assignment|
+      assignment.cohort.students.each do |student|
+        student_assignment = StudentAssignment.for_student(student).for_assignment(assignment).first
+        if student_assignment.nil?
+          student_assignment = StudentAssignment.new(:student_id    => student.id, 
+                                                     :assignment_id => assignment.id)
+          student_assignment.save!
+        end
+      end
+    end
+  end
+
   #############################################################################
   # Access control methods
   #############################################################################

--- a/lib/cron_jobs.rb
+++ b/lib/cron_jobs.rb
@@ -7,6 +7,7 @@ module Ost
 
   def execute_cron_jobs
     AssignmentPlan.build_and_distribute_assignments
+    Assignment.create_missing_student_assignments
     StudentAssignment.note_if_due!
     ScheduledNotificationMailer.send!
   end


### PR DESCRIPTION
This is the first of two pull requests designed to remove the lazy instantiation of StudentAssignments.

Currently, when the cron tasks are run, AssignmentPlan#build_and_distribute_assignments creates an Assignment for each cohort in any unassigned-but-assignable AssignmentPlans.  The Assignment shows up in various displays (both Student and Instructor views of a Klass, for example) and acts as a handle for the issued assignment.  The Student-specific containers for work on the assignment (StudentAssignment) are not currently created until the Student clicks on the Assignment link and AssignmentsController#show is invoked.  This behavior isn't necessarily bad in itself, but it tends to "leak" into other aspects of OST (for instance, the grades spreadsheet, which queries for StudentAssignments) because those features need to check if the StudentAssignment exists at all and then decide how to handle those which are missing.  (StudentAssignments for Students which have not yet viewed their Assignment will not exists as records in the database.)

This initial pull request moves the creation of StudentAssignments into a cron task.  For each Assignment, missing StudentAssignments for any Students in its Cohort  will be created.  This is completely backward-compatible with the notion that the Student viewed the Assignment but did nothing.  It is also compatible with the existing lazy-instantiation of the StudentAssignments inside the AssignmentsController, but will essentially render that logic obsolete.  It also handles the case where a Student is added to a Cohort after the issuing of the Assignment.

Once this code is pushed to the production environment, a second pull request containing the removal of the AssigmentsController#show logic will be created.  One could argue that this second phase is optional, but it seems unwise to have StudentAssignment creation logic repeated in two places...

There could also be a third pull request which removes soon-to-be-obsolete logic dealing with this issue from various OST features and displays.
