### PR TITLE
performance improvements for Class report.xls generation

### DIFF
--- a/app/views/classes/report.xls.erb
+++ b/app/views/classes/report.xls.erb
@@ -1,24 +1,23 @@
 <%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<% 
-present_user_is_researcher = present_user.is_researcher? 
+<% present_user_is_researcher = present_user.is_researcher? %>
 
-visible_students = Student.joins{section}.where{section.klass_id == my{@klass}.id}.visible(present_user).active
+<%  
+  ae_info = { }
+  @klass.learning_plan.topics.each do |topic|
+    topic.topic_exercises.each do |te|
+      te.assignment_exercises.each do |ae|
+        ae_info[ae] = { :number       => ae.number,
+                        :quadbase_id  => ae.topic_exercise.exercise.quadbase_id,
+                        :concept      => ae.topic_exercise.concept.try(:name),
+                        :tag_list     => ae.tag_list }
+      end
+    end
+  end
 
-ses = StudentExercise.joins{student_assignment.student.section.klass.course} \
-                     .joins{student_assignment.student.cohort} \
-                     .joins{assignment_exercise.assignment.assignment_plan} \
-                     .joins{assignment_exercise.topic_exercise.exercise} \
-                     .joins{assignment_exercise.topic_exercise.concept.outer} \
-                     .joins{assignment_exercise.topic_exercise.topic}. 
-                      where{student_assignment.student_id.in(visible_students.select{id})}.  # Current class
-                      order{student_assignment.student_id}.
-                      order{assignment_exercise.assignment.assignment_plan.starts_at}.
-                      order{assignment_exercise.number}
-                      
+  response_time_query = ResponseTime.where{ (note =="READY") & (page == "feedback") }
 %>
-            
 <%#         
 ses.find_each do |se|
   csv << [
@@ -68,16 +67,24 @@ ses.find_each do |se|
         <Cell><Data ss:Type="String">Overall Score</Data></Cell>
         <Cell><Data ss:Type="String"># Feedback Loads</Data></Cell>
       </Row>
-    <% ses.find_each do |se| %>
+      <% @klass.sections.each do |section| %>
+        <% section_name = section.name %>
+        <% section.students.visible(present_user).each do |student| %>
+          <% student_full_name = student.full_name(present_user) %>
+          <% cohort_name       = student.cohort.name %>
+          <% StudentAssignment.for_student(student).each do |sa| %>
+            <% assignment_plan_name = sa.assignment.assignment_plan.name %>
+            <% sa.student_exercises.each do |se| %>
+              <% ae = se.assignment_exercise %>
       <Row>
-        <Cell><Data ss:Type="String"><%= se.student.full_name(present_user) %></Data></Cell>
-        <Cell><Data ss:Type="String"><%= se.student_assignment.student.section.name %></Data></Cell>
-        <Cell><Data ss:Type="String"><%= se.student_assignment.student.cohort.name %></Data></Cell>
-        <Cell><Data ss:Type="String"><%= se.assignment_exercise.assignment.assignment_plan.name %></Data></Cell>
-        <Cell><Data ss:Type="Number"><%= se.assignment_exercise.number %></Data></Cell>
-        <Cell><Data ss:Type="String"><%= se.assignment_exercise.topic_exercise.exercise.quadbase_id %></Data></Cell>
-        <Cell><Data ss:Type="String"><%= concept = se.assignment_exercise.topic_exercise.concept; concept.name if !concept.nil? %></Data></Cell>
-        <Cell><Data ss:Type="String"><%= se.assignment_exercise.tag_list %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= student_full_name %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= section_name %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= cohort_name %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= assignment_plan_name %></Data></Cell>
+        <Cell><Data ss:Type="Number"><%= ae_info[ae][:number] %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= ae_info[ae][:quadbase_id] %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= ae_info[ae][:concept] %></Data></Cell>
+        <Cell><Data ss:Type="String"><%= ae_info[ae][:tag_list] %></Data></Cell>
         <Cell><Data ss:Type="String"><%= se.free_response %></Data></Cell>
         <Cell><Data ss:Type="Number"><%= se.free_response_confidence %></Data></Cell>
         <Cell><Data ss:Type="Number"><%= se.selected_answer %></Data></Cell>
@@ -85,9 +92,12 @@ ses.find_each do |se|
         <Cell><Data ss:Type="String"><%= tf_to_yn(se.was_submitted_late) %></Data></Cell>
         <Cell><Data ss:Type="Number"><%= se.feedback_credit_multiplier %></Data></Cell>
         <Cell><Data ss:Type="Number"><%= se.score %></Data></Cell>
-        <Cell><Data ss:Type="Number"><%= se.response_times.where{page == "feedback"}.where{note == "READY"}.count %></Data></Cell>
+        <Cell><Data ss:Type="Number"><%= response_time_query.where{ |rt| rt.response_timeable_id == se.id }.count %></Data></Cell>
       </Row>
-    <% end %>
+            <% end %>
+          <% end %> 
+        <% end %>
+      <% end %>
     </Table>
   </Worksheet>
   <Worksheet ss:Name="Info">


### PR DESCRIPTION
This pull request reduces Class report.xls generation time by 75%.

There are two components to this change.

First, information which doesn't change inside a loop is store in a local variable, preventing many redundant queries.  (Even though the queries are cached, executing the query engages the Rails query mechanisms and takes some time.  Since many of the queries are multi-step [thing.otherthing.something.value] this adds up quickly.)

Secondly, AssignmentExercise invariants (number, concept, etc.) are precomputed and stored in a hash for easy lookup.  This has the same effect as above for avoiding queries, but applies to items which change often inside the inner code loops.
