### PR TITLE
added comments to emphasize linkage between these two files

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,6 +24,10 @@
 
 set :output, "log/whenever_cron.log"
 
+##
+## NOTE: Changes here should also be reflected in lib/cron_jobs.rb
+##
+
 every 5.minutes do
   runner "AssignmentPlan.build_and_distribute_assignments"
   runner "Assignment.create_missing_student_assignments"

--- a/lib/cron_jobs.rb
+++ b/lib/cron_jobs.rb
@@ -6,6 +6,11 @@ module Ost
   module Cron
 
   def execute_cron_jobs
+
+    ##
+    ## NOTE: Changes here should also be reflected in config/schedule.rb
+    ##
+
     AssignmentPlan.build_and_distribute_assignments
     Assignment.create_missing_student_assignments
     StudentAssignment.note_if_due!


### PR DESCRIPTION
Changes made in either of lib/cron_jobs.rb or config/schedule.rb need to be reflected in the other file.  A comment to this effect has been added to (hopefully) prevent future confusion.
