### PR TITLE
Prevent recent QB update from breaking OST

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -52,11 +52,11 @@ class Exercise < ActiveRecord::Base
   end
   
   def get_credit(choice_index)
-    content["simple_question"]["answer_choices"][choice_index]["credit"]
+    content["simple_question"]["answer_choices"][choice_index]["credit"].to_f
   end
   
   def correct_choice_index
-    content["simple_question"]["answer_choices"].index{|ac| ac["credit"] == 1}
+    content["simple_question"]["answer_choices"].index{|ac| ac["credit"].to_f == 1}
   end
   
   def num_choices


### PR DESCRIPTION
This forces a conversion from string to float for problem credit.
