### PR TITLE
made use of sudo_enabled more consistent

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -37,8 +37,8 @@ class Assignment < ActiveRecord::Base
   end
   
   def destroyable?
-    # TODO eventually might allow destruction if sudo enabled
-    errors.add(:base, "This assignment cannot be deleted because it has been given out to students") \
+    return true if sudo_enabled?
+    errors.add(:base, "This assignment cannot be deleted because it has been given out to students (unless sudo_enabled is set)") \
       if assigned?
     errors.none?
   end

--- a/app/models/assignment_exercise.rb
+++ b/app/models/assignment_exercise.rb
@@ -21,8 +21,8 @@ class AssignmentExercise < ActiveRecord::Base
   attr_accessible :assignment, :topic_exercise, :assignment_id
 
   def destroyable?
-    return true if WebsiteConfiguration.get_value(:sudo_enabled)
-    errors.add(:base, "This assignment exercise cannot be deleted because it has already been distributed to students") \
+    return true if sudo_enabled?
+    errors.add(:base, "This assignment exercise cannot be deleted because it has already been distributed to students (unless sudo_enabled is set)") \
       if student_exercises.any?
     errors.none?
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -84,8 +84,8 @@ protected
   end
 
   def destroyable?
-    return true if WebsiteConfiguration.get_value(:sudo_enabled)
-    errors.add(:base, "Cannot delete an exercise that has been assigned.") \
+    return true if sudo_enabled?
+    errors.add(:base, "This exercise cannot be deleted because it has been assigned (unless sudo_enabled is set).") \
       if topic_exercises.any?{|te| te.assigned?}
     errors.empty?
   end

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -166,9 +166,9 @@ class Klass < ActiveRecord::Base
 protected
 
   def destroyable?
-    return true if sections.empty? || sudo_enabled?
-    errors.add(:base, "This class cannot be deleted because it has sections.")
-    false
+    return true if sudo_enabled?
+    errors.add(:base, "This class cannot be deleted because it has sections (unless sudo_enabled is set).") if sections.any?
+    errors.none?
   end
 
   def set_first_instructor

--- a/app/models/student_assignment.rb
+++ b/app/models/student_assignment.rb
@@ -43,11 +43,10 @@ class StudentAssignment < ActiveRecord::Base
     assignment_coworkers.includes(:student).any?{|cw| cw.student.user_id == user.id}
   end
   
-  attr_accessor :sudo_enabled
-
   def destroyable?
-    sudo_enabled || false
-    # raise NotYetImplemented
+    return true if sudo_enabled?
+    errors.add(:base, "This student assignment cannot be destroyed unless sudo_enabled is set")
+    errors.none?
   end
   
   def mark_complete_if_indicated!

--- a/app/models/student_exercise.rb
+++ b/app/models/student_exercise.rb
@@ -182,8 +182,8 @@ class StudentExercise < ActiveRecord::Base
   end
 
   def destroyable?
-    return true if WebsiteConfiguration.get_value(:sudo_enabled)
-    errors.add(:base, "This StudentExercise cannot be destroyed unless sudo_enabled is true")
+    return true if sudo_enabled?
+    errors.add(:base, "This student exercise cannot be destroyed unless sudo_enabled is set")
     errors.none?
   end
   

--- a/app/models/topic_exercise.rb
+++ b/app/models/topic_exercise.rb
@@ -22,8 +22,8 @@ class TopicExercise < ActiveRecord::Base
   scope :for_tests, where{reserved_for_tests == true}
   
   def destroyable?
-    return true if WebsiteConfiguration.get_value(:sudo_enabled)
-    errors.add(:base, "This exercise cannot be deleted because it has already been assigned.") if assigned?
+    return true if sudo_enabled?
+    errors.add(:base, "This exercise cannot be deleted because it has already been assigned (unless sudo_enabled is set).") if assigned?
     errors.none?
   end
   


### PR DESCRIPTION
Now all classes which require sudo_enabled to be set use it uniformly.

Previously, most classes used the global flag but some used a per-object attribute.  Now all classes respect the global flag.
