### PR TITLE
restored deleted setting of @errors

### DIFF
--- a/app/views/student_exercises/show.html.erb
+++ b/app/views/student_exercises/show.html.erb
@@ -5,6 +5,8 @@
 
 <%= render :partial => "question", :locals => { :student_exercise => @student_exercise } %>
 
+<% @errors = @student_exercise.errors %>
+
 <% if @student_exercise.present_free_response_and_selected_answer? %>
 
   <%= section "Free Response", {:classes => ''} do %>


### PR DESCRIPTION
The setting of @errors in the StudentExercise view was deleted in the recent refactoring, resulting in flash errors not being shown.  This restores that feature.
