### PR TITLE
Popup dialog improvement

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -39,7 +39,10 @@ function open_specified_dialog(name, is_modal, height, width, title, body) {
     height: height, 
     width: width,
     title: title,
-    position: 'center'
+    position: 'center',
+    open: function () {
+      $(document).trigger('after_dialog_open');
+    }
   });
 
   refresh_buttons();

--- a/app/helpers/jquery_helper.rb
+++ b/app/helpers/jquery_helper.rb
@@ -49,10 +49,10 @@ module JqueryHelper
   end
   
   def specified_dialog(name=nil, title=nil, options={}, &block)
+    @body = capture(&block)
     @name ||= name
     @title ||= title
     @options = options
-    @body = capture(&block)
     render :template => 'shared/specified_dialog'
   end
 end

--- a/app/views/registration_requests/_new.html.erb
+++ b/app/views/registration_requests/_new.html.erb
@@ -8,7 +8,7 @@
     <%= f.hidden_field :section_id, :value => @klass.sections.first.id %>
   <% else %>
     <div class="field">
-      Choose the section for which you are registering:<br/>
+      Choose the section for which you are registering:<br/><br/>
       <%= f.select :section_id, options_from_collection_for_select(@klass.sections, :id, :name)%>
     </div>
   <% end %>

--- a/app/views/registration_requests/new.js.erb
+++ b/app/views/registration_requests/new.js.erb
@@ -1,8 +1,8 @@
 <%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<% dialog_height_px = @klass.allow_student_specified_id ? 270 : 150 %>
+<% dialog_height = @klass.allow_student_specified_id ? 375 : 225 %>
 
-<%= message_dialog "Submit a Registration Request", {:width => 400, :height => dialog_height_px} do %>
+<%= message_dialog "Submit a Registration Request", {:width => 400, :height => dialog_height} do %>
   <%= render :partial => 'new' %>
 <% end %>

--- a/app/views/topic_exercises/_form.html.erb
+++ b/app/views/topic_exercises/_form.html.erb
@@ -33,3 +33,9 @@
   </div>
 
 <% end %>
+
+<script type="text/javascript">
+  $(document).on('after_dialog_open', function() {
+    $('#exercise_url').focus();
+  });
+</script>

--- a/app/views/topic_exercises/new.js.erb
+++ b/app/views/topic_exercises/new.js.erb
@@ -2,7 +2,7 @@
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 
-<%= message_dialog "Add a New Exercise", {:width => 650, :height => 280} do %>
+<%= message_dialog "Add a New Exercise", {:width => 650, :height => 370} do %>
   <%= render :partial => 'topic_exercises/form' %>
 <% end %>
 


### PR DESCRIPTION
This should close issues #180 and #196.

This PR corrects a problem with conflicting reuse of instance variables in templates/partials (specifically, @options).  It also adjusts the size of certain dialogs (new Exercise and RegistrationRequest) and also automatically focuses on the "exercise url" inside the new Exercise dialog. @matthewmoravec
