### PR TITLE
Case-insensitive display ordering

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -42,10 +42,8 @@ class Student < ActiveRecord::Base
   scope :std_sort, lambda { |user_arg| 
     if user_arg.is_researcher? || user_arg.is_visitor?
       joins{user}.order{user.research_id.asc}
-      # order(:user => :research_id.asc).joins(:user)
     else
-      joins{user}.order{user.last_name.asc}
-      # order(:user => :last_name.asc).joins(:user)
+      joins{user}.order{lower(user.last_name).asc}
     end
   }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,19 +57,19 @@ class User < ActiveRecord::Base
   def self.error_notice_recipients; active_administrators.where{receives_error_notices == true}; end
 
   def self.administrators_for_display
-    User.administrators.uniq.sort_by{ |user| user.last_name }
+    User.administrators.uniq.sort_by{ |user| user.last_name.downcase }
   end
 
   def self.non_administrator_educators_for_display
-    User.non_administrators.educators.uniq.sort_by{ |user| user.last_name }
+    User.non_administrators.educators.uniq.sort_by{ |user| user.last_name.downcase }
   end
 
   def self.non_administrator_non_educator_researchers_for_display
-    User.non_administrators.non_educators.researchers.uniq.sort_by{ |user| user.last_name }
+    User.non_administrators.non_educators.researchers.uniq.sort_by{ |user| user.last_name.downcase }
   end
 
   def self.non_administrator_non_educator_non_researchers_for_display
-    User.non_administrators.non_educators.non_researchers.uniq.sort_by{ |user| user.last_name }
+    User.non_administrators.non_educators.non_researchers.uniq.sort_by{ |user| user.last_name.downcase }
   end
 
   def full_name


### PR DESCRIPTION
This PR changes Student/User ordering by last name to be case-insensitive (some users entered their names all lowercase).  It affects the admin/dev toolboxes, Class roster and assignment pages, and various reports.

Researchers still see [consented] Students sorted by research id.

There is a difference in how the development and production databases treat <code>asc</code> in the following scope in app/models/student.rb:

``` ruby
  scope :std_sort, lambda { |user_arg| 
    if user_arg.is_researcher? || user_arg.is_visitor?
      joins{user}.order{user.research_id.asc}
    else
      joins{user}.order{user.last_name.asc}
    end
  }
```

so the code was changed to:

``` ruby
  scope :std_sort, lambda { |user_arg| 
    if user_arg.is_researcher? || user_arg.is_visitor?
      joins{user}.order{user.research_id.asc}
    else
      joins{user}.order{lower(user.last_name).asc}
    end
  }
```

to make it more database-agnostic.
