### PR TITLE
Add "Registration Status" section to Class show page

### DIFF
--- a/app/views/classes/_student_assignments.html.erb
+++ b/app/views/classes/_student_assignments.html.erb
@@ -12,38 +12,38 @@
 
     <% show_grades = student_assignments.inject(true) { |result, sa| result && sa.learning_condition.show_correctness_feedback?(sa) } %>
 
-    <% if student.has_dropped? %>
-      <p>You have dropped this class.</p>
-    <% elsif student_assignments.none? %>
-      <p>No assignments yet!</p>
-    <% else %>
+    <% if !student.has_dropped? %>
+      <% if student_assignments.none? %>
+        <p>No assignments yet!</p>
+      <% else %>
 
-      <table class="list student_assignment">
-        <tr>
-          <th class="assignment_number"></th>
-          <th class="assignment_name">Name</th>
-          <th class="assignment_start">Starts</th>
-          <th class="assignment_end">Ends</th>
-          <% if show_grades %>
-            <th class="assignment_grade percentage">Grade (%)</th>
-          <% end %>
-        </tr>
-
-        <% student_assignments.each do |student_assignment| %>        
-          <% assignment_plan = student_assignment.assignment.assignment_plan %>
+        <table class="list student_assignment">
           <tr>
-            <td class="assignment_number"><%= 1+assignment_plan.number %>.</td>
-            <td class="assignment_name"><%= link_to(assignment_plan.name, student_assignment.assignment) %></td>
-            <td class="assignment_start"><%= standard_date(assignment_plan.starts_at) %></td>
-            <td class="assignment_end"><%= standard_date(assignment_plan.ends_at) %></td>
+            <th class="assignment_number"></th>
+            <th class="assignment_name">Name</th>
+            <th class="assignment_start">Starts</th>
+            <th class="assignment_end">Ends</th>
             <% if show_grades %>
-              <td class="assignment_grade"><%= standard_percentage(student_assignment.score) %></td>
+              <th class="assignment_grade percentage">Grade (%)</th>
             <% end %>
           </tr>
-        <% end %>
 
-      </table>
+          <% student_assignments.each do |student_assignment| %>        
+            <% assignment_plan = student_assignment.assignment.assignment_plan %>
+            <tr>
+              <td class="assignment_number"><%= 1+assignment_plan.number %>.</td>
+              <td class="assignment_name"><%= link_to(assignment_plan.name, student_assignment.assignment) %></td>
+              <td class="assignment_start"><%= standard_date(assignment_plan.starts_at) %></td>
+              <td class="assignment_end"><%= standard_date(assignment_plan.ends_at) %></td>
+              <% if show_grades %>
+                <td class="assignment_grade"><%= standard_percentage(student_assignment.score) %></td>
+              <% end %>
+            </tr>
+          <% end %>
 
+        </table>
+
+      <% end %>
     <% end %>
 
   <% end %>

--- a/app/views/classes/show.html.erb
+++ b/app/views/classes/show.html.erb
@@ -15,8 +15,7 @@
 <%= section "Class Information", {:classes => 'first no_bar class_information' } do %>
 
 <div style="float:right; padding-right:30px">
-  
-  
+    
   <% if is_student %>
 
     <% if student.active? %>
@@ -25,8 +24,6 @@
                   :class => "link_button",
                   :method => :put,
                   :confirm => "Are you sure you want to drop this class?\n\nThis can only be undone by an instructor!" %>
-    <% else %>
-      You dropped this class.
     <% end %>
 
   <% else %>
@@ -185,7 +182,20 @@
 
 <% sees_all_cohort_assignments = is_educator || present_user.is_researcher? || present_user.is_administrator? %>
 
-<% if !present_user.can_read_children?(@klass.cohorts.first, :assignments) %>
+<%= section "Registration Status", {:classes => "registration_status"} do %>
+  <% if student.has_dropped? %>
+    <p>You have dropped this class.</p>
+  <% else %>
+    <% if student.registered? %>
+      <p>You are fully registered for this class.</p>
+    <% elsif student.auditing? %>
+      <p>You are auditing this class.</p>
+    <% end %>
+    <p>You are in section <%= student.section.name %>.</p>
+  <% end %>
+<% end %>
+
+<% if student.has_dropped? || !present_user.can_read_children?(@klass.cohorts.first, :assignments) %>
   <%= section "Assignments", {:classes => "assignments"} do %>
     <p>Assignments are only visible to this section's students and educators.</p>
   <% end %>
@@ -195,10 +205,10 @@
                                                                  :klass   => @klass, 
                                                                  :collapsible_section => sees_all_cohort_assignments} %>
   <% end %>
-  
-  <% if sees_all_cohort_assignments %>
-    <%= render :partial => 'nonstudent_assignments', :locals => {:present_user => present_user, :klass => @klass} %>
-  <% end %>
+<% end %>
+
+<% if sees_all_cohort_assignments %>
+  <%= render :partial => 'nonstudent_assignments', :locals => {:present_user => present_user, :klass => @klass} %>
 <% end %>
 
 <%


### PR DESCRIPTION
This should close issue #188.

This PR adds a "Registration Status" section to the Class show page, telling Students their registration status and section:

![Screen Shot 2013-02-12 at 7 32 23 PM](https://f.cloud.github.com/assets/1851667/151702/03692b08-758e-11e2-8302-a8ad68c38a99.png)

If the Student has dropped the class, the display is:

![Screen Shot 2013-02-12 at 7 33 12 PM](https://f.cloud.github.com/assets/1851667/151704/2fc29da6-758e-11e2-9ac5-2c7107fff153.png)
