### PR TITLE
Adds "Draw an Answer" to student exercises

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem "fog", "~> 1.3.1"
 
 gem 'remotipart', '~> 1.0'
 
+gem 'sketchily', '~> 0.2.0'
+
 group :development, :test do
   gem 'debugger', '~> 1.1.4'
   gem 'faker', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,9 @@ GEM
       multi_json (~> 1.0)
       rubyzip
     sexp_processor (3.2.0)
+    sketchily (0.2.0)
+      jquery-rails
+      rails (>= 3.1)
     spork (1.0.0rc3)
     spork-rails (3.2.0)
       rails (>= 3.0.0, < 3.3.0)
@@ -343,6 +346,7 @@ DEPENDENCIES
   rspec-rerun
   rvm-capistrano
   sass-rails (~> 3.2.3)
+  sketchily (~> 0.2.0)
   spork-rails
   sqlite3 (~> 1.3.6)
   squeel (~> 1.0.5)

--- a/app/controllers/free_responses_controller.rb
+++ b/app/controllers/free_responses_controller.rb
@@ -49,6 +49,8 @@ protected
         TextFreeResponse.new(params[:free_response])
       when 'FileFreeResponse'
         FileFreeResponse.new(params[:free_response])
+      when 'DrawingFreeResponse'
+        DrawingFreeResponse.new(params[:free_response])
       else
         raise AbstractController::ActionNotFound
       end

--- a/app/models/drawing_free_response.rb
+++ b/app/models/drawing_free_response.rb
@@ -1,0 +1,9 @@
+
+class DrawingFreeResponse < FreeResponse
+
+  validates :content, :presence => true
+
+  def as_text
+    "[Drawing]"
+  end
+end

--- a/app/views/drawing_free_responses/_form.html.erb
+++ b/app/views/drawing_free_responses/_form.html.erb
@@ -1,0 +1,25 @@
+<%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
+    License version 3 or later.  See the COPYRIGHT file for details. %>
+
+<%
+  html_ids[:drawing] = "free_response_content_#{free_response.non_nil_id}"
+%>
+
+<div style="margin-bottom:12px" class="actions">
+  <div style="display:inline-block; padding-top:5px">
+    Sketch your answer: <%= link_to_help 'drawing_free_response', "", {:title => 'Drawing Answers'} %>
+  </div>
+  <span style="float:right">
+    <%= link_to_function "Cancel", "cancel_free_response_edit('#{free_response.non_nil_id}', false);" %>
+    &nbsp;&nbsp;&nbsp;
+    <%= f.submit "Save Draft", :class => 'link_button', :title => 'You can continue working on this exercise after saving' %>
+  </span>
+</div>
+
+<%= f.sketchily :content, 
+                :hide_menu => true, 
+                :hide_image_tool => false,
+                :width => 560, :height => 450, 
+                :canvas_expansion => 0, 
+                :canvas_width => 490, :canvas_height => 310 %>
+

--- a/app/views/drawing_free_responses/_show.html.erb
+++ b/app/views/drawing_free_responses/_show.html.erb
@@ -1,0 +1,2 @@
+<%= sketchily_show free_response.content %>      
+ 

--- a/app/views/student_exercises/_add_and_turn_in_free_responses.html.erb
+++ b/app/views/student_exercises/_add_and_turn_in_free_responses.html.erb
@@ -16,6 +16,9 @@
   <%= link_to "Add Text Answer", 
               new_student_exercise_free_response_path(student_exercise, {:type => 'TextFreeResponse'}), 
               :remote => true %> | 
+  <%= link_to "Draw an Answer", 
+              new_student_exercise_free_response_path(student_exercise, {:type => 'DrawingFreeResponse'}),
+              :remote => true %> |
   Upload Photo(s) from 
   <%= link_to "PC", 
               new_student_exercise_free_response_path(student_exercise, {:type => 'FileFreeResponse'}), 


### PR DESCRIPTION
Adds a "Draw an Answer" option to student exercise work.  All the other features of free responses still apply here (sorting, canceling editing, etc).   

Thanks to @Dantemss for his great work on the sketchily gem to make this PR pretty straightforward.

@kevinburleigh75 should do a code review and @kjdav should test it out before we merge.
