### PR TITLE
Fix exception caused by compound errors in BFC form

### DIFF
--- a/app/models/basic_feedback_condition.rb
+++ b/app/models/basic_feedback_condition.rb
@@ -265,10 +265,12 @@ protected
   end
   
   def credit_window_within_availability_window
-    errors.add(:credit_closes_delay_days, "must fall within availability window") \
-      if AvailabilityClosesOption::DELAY_AFTER_OPEN == availability_closes_option &&
-         CreditClosesOption::DELAY_AFTER_OPEN       == credit_closes_option &&
-         credit_closes_delay_days > availability_closes_delay_days
+    if credit_closes_delay_days && availability_closes_delay_days
+      errors.add(:credit_closes_delay_days, "must fall within availability window") \
+        if AvailabilityClosesOption::DELAY_AFTER_OPEN == availability_closes_option &&
+           CreditClosesOption::DELAY_AFTER_OPEN       == credit_closes_option &&
+           credit_closes_delay_days > availability_closes_delay_days
+    end
   end
 
   def not_applicable_event_only_for_never


### PR DESCRIPTION
When one validation adds to <code>errors</code>, following validations still get run.  In this case, the missing values validation detected the missing delays but the credit window validation still attempted to use those values in its calculation.  This PR fixes that problem.
