### PR TITLE
Open external link in new tab/window

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,3 +66,17 @@ function sum(array) {
   }
   return sum;
 }
+
+// Open all non-local links in a new tab/window
+//  http://stackoverflow.com/questions/4086988/how-do-i-make-link-to-open-external-urls-in-a-new-window
+$(document).ready(function() {
+  $("a").click(function() {
+    link_host = this.href.split("/")[2];
+    document_host = document.location.href.split("/")[2];
+
+    if (link_host != document_host) {
+      window.open(this.href);
+      return false;
+    }
+  });
+});


### PR DESCRIPTION
This should close issue #41.

Instead of targeting the specific links mentioned in this issue, or links in a certain place (like uber_lists), I decided that what we really want is to have all links which leave our site to open in a new tab/window.

This has the somewhat unfortunate side effect of eliminating a user's own preferences in this regard.  Perhaps this isn't such a big deal.
