### PR TITLE
Add margin to radio buttons and checkboxes

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -52,6 +52,15 @@ input, textarea {
   padding: 6px;
 }
 
+input[type='checkbox'] {
+  margin-left: 2px;
+}
+
+input[type='radio'] {
+  margin-left:  3px;
+  margin-right: 2px;
+}
+
 pre {
   background-color: #eee;
   padding: 10px;


### PR DESCRIPTION
This PR should close issue #145.

Margin has been added to _all_ radio buttons and checkboxes by default, which should avoid the clipping on all forms and not just the one mentioned in the original issue.
