### PR TITLE
ignore db:dump/db:load related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bundle
 db/*.sqlite3*
+db/data.yml*
 log/*.log*
 tmp/**/*
 *.DS_Store


### PR DESCRIPTION
This PR adds <code>db/data.yml*</code> to .gitignore.  These files are related to db:load and db:dump activities.
