### PR TITLE
Make "teach this course" links visible only to admins and CourseInstructors

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -22,7 +22,9 @@
         <div style="padding: 5px 0 8px" class="test test_section">
           <p><b><%= course.name %></b></p>
           <p><%= course.description %></p>
-          <p style="margin-bottom: 0px"><%= link_to "Teach this course", new_course_klass_path(course), :test => "teach" %></p>
+          <% if course.is_instructor?(present_user) || present_user.is_administrator? %>
+            <p style="margin-bottom: 0px"><%= link_to "Teach this course", new_course_klass_path(course), :test => "teach" %></p>
+          <% end %>
           <%# TODO put in a "last offered: 2012" note %>
         </div>
       <% end %>


### PR DESCRIPTION
This PR should close issue #19.

The "Teach this course" link for each Course is now only visible to those who can actually create a new Class for that Course: admins and CourseInstructors.
