### PR TITLE
Fix flicker in "javascript not enabled" alert

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -174,13 +174,9 @@
           
       </div>
 
-      <%= attention_tag(["Please enable JavaScript in your browser! Many #{SITE_NAME} pages will not work properly without it."], :alert, "js_not_enabled_alert remove_by_js") %>
-
-      <script type="text/javascript">
-        $(document).ready(function() {
-          $('.remove_by_js').replaceWith('');
-        });
-      </script>
+      <noscript>
+        <%= attention_tag(["Please enable JavaScript in your browser! Many #{SITE_NAME} pages will not work properly without it."], :alert, "js_not_enabled_alert remove_by_js") %>
+      </noscript>
 
       <%# #########################   MAIN   ############################## #%>
      


### PR DESCRIPTION
This relates to issues #182 and #217.

Content of alert is not inside <noscript> tags, which shouldn't be rendered at all unless javascript is disabled or unavailable.
