### PR TITLE
Fix external links in popup dialogs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,6 +46,7 @@ function open_specified_dialog(name, is_modal, height, width, title, body) {
   });
 
   refresh_buttons();
+
   $("#" + name + "_dialog").dialog('open');
   $("#" + name + "_dialog").scrollTop(0);   
   $("#" + name + "_dialog").dialog('open').closeOnClickOutside();
@@ -69,7 +70,7 @@ function sum(array) {
 
 // Open all non-local links in a new tab/window
 //  http://stackoverflow.com/questions/4086988/how-do-i-make-link-to-open-external-urls-in-a-new-window
-$(document).ready(function() {
+function open_external_links_elsewhere () {
   $("a").click(function() {
     link_host = this.href.split("/")[2];
     document_host = document.location.href.split("/")[2];
@@ -79,4 +80,7 @@ $(document).ready(function() {
       return false;
     }
   });
+}
+$(document).ready(function() {
+  open_external_links_elsewhere();
 });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -12,6 +12,7 @@ function refresh_buttons() {
    $(".trash_button").button({icons: {primary: "ui-icon-trash"}, text: false });
    $(".calendar_button").button({icons: {primary: "ui-icon-calendar"}, text: false });
    refresh_datetime_pickers();
+   open_external_links_elsewhere();
 }
 
 function remove_fields(link) {


### PR DESCRIPTION
This PR relates to issues #219 and #41.

Because the HTML for popup dialogs doesn't exist when the page is loaded, the ready() callback which causes external links to be opened in a new tab/window wasn't able to set the appropriate action on &lt;a&gt; tags.

This PR adds that functionality to refresh_buttons(), which is called everywhere such action is needed.  
