### PR TITLE
Fix help dialog changes to nav menu <li> entries

### DIFF
--- a/app/views/help/blurbs/_text_free_response.html.erb
+++ b/app/views/help/blurbs/_text_free_response.html.erb
@@ -1,28 +1,28 @@
 <p>Here are some helpful tips for entering your answer in the free response box.</p>
 
 <style type="text/css">
-  li {
+  li.help_list_item {
     padding-top: 4px;
     padding-bottom: 4px;
   }
 </style>
 
 <ul>
-  <li>
+  <li class="help_list_item">
     You can write math in this text box using a syntax called LaTeX.  Just make 
     sure any LaTeX is surrounded by dollar signs, e.g. $x^2+1$, or double dollar signs 
     ($$x^2+1$$) to put the math centered on its own line.
   </li>
-  <li>
+  <li class="help_list_item">
     Click the "Preview" button to see a rendering of your response, including your entered LaTeX math.
   </li>
-  <li>
+  <li class="help_list_item">
     You can also use the "LaTeX Editor" link to help write LaTeX syntax.  Clicking this link will open
     a popup window.  Type into the editor and use the buttons for different kinds of math.  A preview 
     of the math will show up in the popup, then you can click "Copy to Document" to transfer the editor
     content back to the exercise page.
   </li>
-  <li>
+  <li class="help_list_item">
     For less-than and greater-than in LaTeX math, make sure to put spaces around the 
     "&lt;" and "&gt;" signs so the browser doesn't think you're writing HTML.  Alternatively, use 
     the "\lt" and "\gt" latex symbols.)


### PR DESCRIPTION
This PR partially addresses issue #230.

In a partial, &lt;style&gt; CSS content is applied to the whole page, not just the partial content.  In this case, an adjustment to &lt;li&gt; spacing for the help dialog was being applied to the exercise navigation list on the right side of the screen.

To solve this problem, class tags were added to the help-related elements and the CSS was changed to target them. 
