### PR TITLE
open_specified_dialog() code simplification

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,7 +30,7 @@
 
 function open_specified_dialog(name, is_modal, height, width, title, body) {
   $('#' + name + '_dialog_errors').html('');
-  
+
   $("#" + name + "_dialog_body").html(body);
   
   $("#" + name + "_dialog").dialog({ 
@@ -44,12 +44,11 @@ function open_specified_dialog(name, is_modal, height, width, title, body) {
       $(document).trigger('after_dialog_open');
     }
   });
-
+  
   refresh_buttons();
 
-  $("#" + name + "_dialog").dialog('open');
-  $("#" + name + "_dialog").scrollTop(0);   
   $("#" + name + "_dialog").dialog('open').closeOnClickOutside();
+  $("#" + name + "_dialog").scrollTop(0);   
 }
 
 function open_message_dialog(is_modal, height, width, title, body) {


### PR DESCRIPTION
This PR remove a redundant call to .dialog('open') by appending the call to closeOnClickOutside() to the first call:

``` ruby
  $("#" + name + "_dialog").dialog('open').closeOnClickOutside();
  $("#" + name + "_dialog").scrollTop(0);   
```
