### PR TITLE
Remove use of @options instance variable in #link_to_help

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -161,11 +161,9 @@ module ApplicationHelper
     @include_help_dialog = true
     @include_mathjax = true if options[:include_mathjax]
     
-    @options = options
-    
     link_to (text.blank? ? image_tag('help_icon_v3.png') : text), 
             blurb_help_path(blurb, :options => options), 
-            :remote => true, :class => @options[:class]
+            :remote => true, :class => options[:class]
   end
   
   def standard_percentage(value)


### PR DESCRIPTION
This PR removes the unnecessary use of an @options instance variable from #link_to_help.  This will help prevent instance variable conflicts like the one seen in issues #180, #196, and #205.
