### PR TITLE
Fixes slidedown with sketchily

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "fog", "~> 1.3.1"
 gem 'remotipart', '~> 1.0'
 
 gem 'babbler', '~> 1.0.0'
-gem 'sketchily', '~> 1.1.0'
+gem 'sketchily', '~> 1.4.1'
 
 group :development, :test do
   gem 'debugger', '~> 1.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     net-ssh (2.5.2)
     net-ssh-gateway (1.1.0)
       net-ssh (>= 1.99.1)
-    newrelic_rpm (3.5.6.46)
+    newrelic_rpm (3.5.8.72)
     nokogiri (1.5.5)
     orm_adapter (0.4.0)
     poltergeist (0.7.0)
@@ -262,8 +262,9 @@ GEM
       multi_json (~> 1.0)
       rubyzip
     sexp_processor (3.2.0)
-    sketchily (1.1.0)
+    sketchily (1.4.1)
       jquery-rails
+      nokogiri
       rails (>= 3.1)
     spork (1.0.0rc3)
     spork-rails (3.2.0)
@@ -353,7 +354,7 @@ DEPENDENCIES
   rspec-rerun
   rvm-capistrano
   sass-rails (~> 3.2.3)
-  sketchily (~> 1.1.0)
+  sketchily (~> 1.4.1)
   spork-rails
   sqlite3 (~> 1.3.6)
   squeel (~> 1.0.5)

--- a/app/views/free_responses/new.js.erb
+++ b/app/views/free_responses/new.js.erb
@@ -1,4 +1,6 @@
 var form = jQuery("<%= ej(render 'free_responses/form') %>");
-form.hide();
-$('#free_responses').append(form);
-form.slideDown(200);
+var div = jQuery("<div></div>");
+div.append(form);
+div.hide();
+$('#free_responses').append(div);
+div.slideDown(200);


### PR DESCRIPTION
This workaround seems to work just fine. Apparently appending before hiding the form is enough, and appending to a div that is not on the dom is also just fine.

I had to update newrelic-rpm, as the version in the gemfile.lock had been yanked.
