### PR TITLE
Fixes AssignmentPlan start/end times at creation

### DIFF
--- a/app/controllers/assignment_plans_controller.rb
+++ b/app/controllers/assignment_plans_controller.rb
@@ -23,8 +23,7 @@ class AssignmentPlansController < ApplicationController
   end
 
   def create
-    @assignment_plan = AssignmentPlan.new(params[:assignment_plan])
-    @assignment_plan.learning_plan = @learning_plan
+    @assignment_plan = AssignmentPlan.new({:learning_plan => @learning_plan}.merge(params[:assignment_plan]))
     @assignment_plan.initialize_starts_ends_at
     raise SecurityTransgression unless present_user.can_create?(@assignment_plan)
     @assignment_plan.save


### PR DESCRIPTION
This should close issue #248.

AssignmentPlans hold their starts_at/ends_at times, but the timezone is stored in the Klass, which is accessed via the LearningPlan (`ap.learning_plan.klass.time_zone`).  This indirection, the order of initialization, and the fact that all times are stored in UTC combined to cause timezone calculation errors.  These errors are especially evident when the range in question spans a DST change...

Because the LearningPlan is already set when updating an AssignmentPlan, the erroneous times were correctable by editing (as mentioned by @matthewmoravec).

This change ensures that the AssignmentPlan's LearningPlan is set _before_ the starts_at/ends_at times during create, and should result in the correct time being stored and displayed.
