### PR TITLE
minor update to exercise refresh blurb 

### DIFF
--- a/app/views/help/blurbs/_refresh_exercises.html.erb
+++ b/app/views/help/blurbs/_refresh_exercises.html.erb
@@ -1,15 +1,21 @@
 <%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<p>When you add an exercise to a topic, <%=SITE_NAME %> saves a version in its cache. If you later update that exercise in Quadbase, <%= SITE_NAME %> will <em>not</em> automatically synchronize those changes.</p>
+<p>When you add an exercise to a topic, <%=SITE_NAME %> saves a version in its cache. If you later update that 
+exercise in Quadbase, <%= SITE_NAME %> will <em>not</em> automatically synchronize those changes.</p>
 
-<p>Click <strong>Refresh Exercises</strong> to update exercises in OST to the latest version in Quadbase.</p>
+<p>Clicking <strong>Refresh Exercises</strong> will update all <i>unversioned</i> exercises to the latest version.</p>
 
-<p><strong>Note the following limitations to Refresh Exercises</strong>:</p> 
+<p><strong>Note the following limitations to using Refresh Exercises</strong>:</p> 
   <ol>
-    <li>Versioned exercises, i.e. those ending in a version number, <em>cannot</em> be updated using Refresh Exercises. To change a versioned exercise, you must create a new question in Quadbase and add the new link to Topics.</li>
+    <li>If you refresh exercises that have already been assigned, students will see the updated exercises in the assignment.
+     However, students who already worked the previous version <i>won't</i> have the opportunity to rework 
+     the new version.</li>
     <p>
-    <li>If you refresh exercises that have already been assigned, students will see the updated exercises in the assignment. However, if a student already entered work using the previous version, they won't have the opportunity to rework the new exercise.</li>
+    <li><i>Avoid altering answer choices for exercises that have already been assigned</i>. Altering answer choices
+    	 -- in particular, removing answers or reordering answers -- is problematic for grading and feedback.</li>
+    </li> 
     <p>
+    <li>Versioned exercises, i.e. those ending in a version number, <em>cannot</em> be refreshed.
+     To change a versioned exercise, you must create a new question in Quadbase and add the new link to Topics.</li>
   </ol>
-  

--- a/app/views/learning_plans/show.html.erb
+++ b/app/views/learning_plans/show.html.erb
@@ -136,7 +136,7 @@
             :method => :put, 
             :remote => true,
             :confirm => "Are you sure?  This could have unintended consequences!  Click the 'Refresh Exercises' help icon for details."
-      x << " " << (link_to_help 'refresh_exercises', "", {:width => 700})
+      x << " " << (link_to_help 'refresh_exercises', "", {:width => 700, :height => 400})
   }
 %>
 


### PR DESCRIPTION
builds on KB's last PR 

Refresh Exercises blurb: 
- adds language to caution against altering answer choices for already assigned exercises 
  - reordered limitations (least important one is last)

Learning plan show page: 
- resized refresh exercises blurb box so dialog box fits text 
