### PR TITLE
Allows non-integral BFC delays (days)

### DIFF
--- a/app/models/basic_feedback_condition.rb
+++ b/app/models/basic_feedback_condition.rb
@@ -9,12 +9,12 @@ class BasicFeedbackCondition < FeedbackCondition
   store_typed_accessor :settings, :boolean, :is_feedback_required_for_credit
   store_typed_accessor :settings, :boolean, :can_automatically_show_feedback
   store_typed_accessor :settings, :integer, :availability_opens_option
-  store_typed_accessor :settings, :integer, :availability_opens_delay_days
+  store_typed_accessor :settings, :float,   :availability_opens_delay_days
   store_typed_accessor :settings, :integer, :availability_closes_option
-  store_typed_accessor :settings, :integer, :availability_closes_delay_days
+  store_typed_accessor :settings, :float,   :availability_closes_delay_days
   store_typed_accessor :settings, :integer, :availability_event
   store_typed_accessor :settings, :integer, :credit_closes_option
-  store_typed_accessor :settings, :integer, :credit_closes_delay_days
+  store_typed_accessor :settings, :float,   :credit_closes_delay_days
   store_typed_accessor :settings, :boolean, :show_correctness_feedback
   store_typed_accessor :settings, :boolean, :show_correct_answer_feedback
   store_typed_accessor :settings, :boolean, :show_high_level_feedback
@@ -34,16 +34,13 @@ class BasicFeedbackCondition < FeedbackCondition
   before_validation :nil_out_blank_regex
 
   validates :availability_opens_delay_days, allow_nil: true,
-                                            numericality: { only_integer: true,
-                                                            greater_than: 0 }
+                                            numericality: { greater_than: 0 }
 
   validates :availability_closes_delay_days, allow_nil: true,
-                                             numericality: { only_integer: true,
-                                                             greater_than: 0 }
+                                             numericality: { greater_than: 0 }
 
   validates :credit_closes_delay_days, allow_nil: true,
-                                       numericality: { only_integer: true,
-                                                       greater_than: 0 }
+                                       numericality: { greater_than: 0 }
 
   validate :delay_days_specified_if_delay_chosen
   validate :credit_window_within_availability_window

--- a/lib/extensions.rb
+++ b/lib/extensions.rb
@@ -164,8 +164,18 @@ module LocalActiveRecordExtensions
       if !precast_value.blank?
         case datatype
         when :integer
-          cast_value = precast_value.to_i
-          error_msg = "is not an integer" if cast_value.to_s != precast_value
+          begin
+            cast_value = Integer(precast_value)
+          rescue
+            error_msg = "is not an integer"
+          end
+        when :float
+          begin
+            ## NOTE: this does NOT allow 'Infinity', '-Infinity', or 'NaN'
+            cast_value = Float(precast_value)
+          rescue
+            error_msg = "is not a float"
+          end
         when :boolean
           case precast_value.downcase
           when "1", "true", "t", "yes"


### PR DESCRIPTION
This PR allows BasicFeedbackCondition feedback availability, credit window, and unavailability delays to be non-integral days (although they must still be greater than 0.0).

Existing BFCs should be unaffected, and no migration is required.  Upon update (even without changes), the delay text for existing BFCs will start reflecting the type change ("3 days" will become "3.0 days"). @kjdav

The code now uses explicit constructor calls (when available) to parse `store_typed_accessor` types.  These raise `ArgumentError` when the input string is not valid, and are less error-prone than the current method of doing comparisons using using `#to_<type>` and `#to_s`. @jpslav
