### PR TITLE
Fixes issue with StudentExercise creation due to Follow-up Question validations  

### DIFF
--- a/app/models/student_exercise.rb
+++ b/app/models/student_exercise.rb
@@ -23,7 +23,7 @@ class StudentExercise < ActiveRecord::Base
                                 :allow_nil => true}
 
   validates :follow_up_answer,
-              :presence => {:if => Proc.new{|se| free_responses.any? && se.requires_follow_up_question?}}
+              :presence => {:if => Proc.new{|se| se.free_responses.any? && se.requires_follow_up_question?}}
 
   # If the free response has been submitted, the next update should have a selected answer
   validates :selected_answer, :presence => {:if => Proc.new{|se| se.free_response_submitted?}}


### PR DESCRIPTION
This PR should correct the issues seen with StudentExercise creation.  Follow-up Question validations were using the SE's LearningCondition, but the join used the id of the as-of-yet unsaved SE, causing nil to be returned.  This has been corrected.

In addition, the validations for missing Follow-up Answers has been changed to ensure the Student cannot lock in his free-response answers.
