### PR TITLE
Adds 'prev' and 'next' links on StudentExercise show page

### DIFF
--- a/app/helpers/student_exercises_helper.rb
+++ b/app/helpers/student_exercises_helper.rb
@@ -5,4 +5,18 @@ module StudentExercisesHelper
   def confidence_labels
     ["Definitely-Wrong", "Probably-Wrong", "Maybe Wrong,-Maybe Right", "Probably-Right", "Definitely-Right"]
   end
+
+  def prev_student_exercise(student_exercise)
+    index = student_exercise.assignment_exercise.number - 1
+    if index > 0
+      student_exercise.student_assignment.student_exercises[index-1]
+    end
+  end
+
+  def next_student_exercise(student_exercise)
+    index = student_exercise.assignment_exercise.number - 1
+    if index < student_exercise.student_assignment.student_exercises.count - 1
+      student_exercise.student_assignment.student_exercises[index+1]
+    end
+  end
 end

--- a/app/views/student_exercises/_nav.html.erb
+++ b/app/views/student_exercises/_nav.html.erb
@@ -1,0 +1,9 @@
+<%# 
+  Clients must provide student_exercise.
+%>
+
+<% prev_se = prev_student_exercise(student_exercise) %>
+<% next_se = next_student_exercise(student_exercise) %>
+
+<%= link_to_if(prev_se, '< prev', prev_se) { } %>
+<%= link_to_if(next_se, 'next >', next_se) { } %>

--- a/app/views/student_exercises/show.html.erb
+++ b/app/views/student_exercises/show.html.erb
@@ -74,3 +74,6 @@
   <%= render 'student_exercises/list', student_exercise: @student_exercise %>
 <% end %>
 
+<% content_for :other_nav_content do %>
+  <%= render 'student_exercises/nav', student_exercise: @student_exercise %>
+<% end %>


### PR DESCRIPTION
This PR should partially address student feedback about navigation between StudentExercises.

'prev' and 'next' links now appear in the side nav area, below the numbered list of StudentExercise links.  If the first/last StudentExercise is being shown, the 'prev'/'last' link will not appear.  The links will take the user to the prev/next StudentExercise regardless of completion or feedback status.
