### PR TITLE
Updates StudentExercise and StudentExercise Feedback navigation

### DIFF
--- a/app/helpers/student_exercises_helper.rb
+++ b/app/helpers/student_exercises_helper.rb
@@ -6,17 +6,42 @@ module StudentExercisesHelper
     ["Definitely-Wrong", "Probably-Wrong", "Maybe Wrong,-Maybe Right", "Probably-Right", "Definitely-Right"]
   end
 
+  def student_exercise_index(student_exercise)
+    student_exercise.assignment_exercise.number - 1
+  end
+
   def prev_student_exercise(student_exercise)
-    index = student_exercise.assignment_exercise.number - 1
+    index = student_exercise_index(student_exercise)
     if index > 0
       student_exercise.student_assignment.student_exercises[index-1]
     end
   end
 
   def next_student_exercise(student_exercise)
-    index = student_exercise.assignment_exercise.number - 1
+    index = student_exercise_index(student_exercise)
     if index < student_exercise.student_assignment.student_exercises.count - 1
       student_exercise.student_assignment.student_exercises[index+1]
     end
+  end
+
+  def available_student_exercise_feedback_path(student_exercise)
+    return nil if student_exercise.nil?
+    student_exercise.is_feedback_available? ? student_exercise_feedback_path(student_exercise) : nil
+  end
+
+  def prev_available_student_exercise_feedback_path(student_exercise)
+    index = student_exercise_index(student_exercise)
+    if index > 0
+      ses = student_exercise.student_assignment.student_exercises[0..index-1]
+      se = ses.reverse.detect{|se| se.is_feedback_available?}
+      available_student_exercise_feedback_path(se)
+    end
+  end
+
+  def next_available_student_exercise_feedback_path(student_exercise)
+    index = student_exercise_index(student_exercise)
+    ses = Array(student_exercise.student_assignment.student_exercises[index+1..-1])
+    se = ses.detect{|se| se.is_feedback_available?}
+    available_student_exercise_feedback_path(se)
   end
 end

--- a/app/views/student_exercises/_exercise_nav.html.erb
+++ b/app/views/student_exercises/_exercise_nav.html.erb
@@ -1,0 +1,33 @@
+<%# 
+  Clients must provide student_exercise.
+%>
+
+<% prev_se        = prev_student_exercise(student_exercise) %>
+<% next_se        = next_student_exercise(student_exercise) %>
+<% feedback_path  = available_student_exercise_feedback_path(student_exercise) %>
+
+<% content_for :other_nav_content do %>
+
+  <%= link_to 'Show Class',       student_exercise.klass %><br/>
+  <%= link_to 'Show Assignment',  student_exercise.assignment %><br/>
+  <% if feedback_path %>
+    <%= link_to 'Show Feedback',  feedback_path %></br>
+  <% end %>
+  <br/>
+
+  <% if [prev_se, next_se, feedback_path].any? %>
+    <% if prev_se %>
+      <%= link_to 'Prev Exercise', prev_se %><br/>
+    <% end %>
+
+    <% if next_se %>
+      <%= link_to 'Next Exercise', next_se %></br>
+    <% end %>
+
+    <br/>
+  <% end %>
+
+  Exercises
+  <%= render 'student_exercises/list', student_exercise: @student_exercise %>
+
+<% end %>

--- a/app/views/student_exercises/_feedback_nav.html.erb
+++ b/app/views/student_exercises/_feedback_nav.html.erb
@@ -1,0 +1,30 @@
+<%# 
+  Clients must provide student_exercise.
+%>
+
+<% prev_se_feeback_path = prev_available_student_exercise_feedback_path(student_exercise) %>
+<% next_se_feeback_path = next_available_student_exercise_feedback_path(student_exercise) %>
+
+<% content_for :other_nav_content do %>
+
+  <%= link_to 'Show Class',       student_exercise.klass %><br/>
+  <%= link_to 'Show Assignment',  student_exercise.assignment %><br/>
+  <%= link_to 'Show Exercise',    student_exercise %><br/>
+  <br/>
+
+  <% if [prev_se_feeback_path, next_se_feeback_path].any? %>
+    <% if prev_se_feeback_path %>
+      <%= link_to 'Prev Available Feedback', prev_se_feeback_path %><br/>
+    <% end %>
+
+    <% if next_se_feeback_path %>
+      <%= link_to 'Next Available Feedback', next_se_feeback_path %><br/>
+    <% end %>
+
+    <br/>
+  <% end %>
+
+  Exercises
+  <%= render 'student_exercises/list', student_exercise: @student_exercise %>
+
+<% end %>

--- a/app/views/student_exercises/_nav.html.erb
+++ b/app/views/student_exercises/_nav.html.erb
@@ -1,9 +1,0 @@
-<%# 
-  Clients must provide student_exercise.
-%>
-
-<% prev_se = prev_student_exercise(student_exercise) %>
-<% next_se = next_student_exercise(student_exercise) %>
-
-<%= link_to_if(prev_se, '< prev', prev_se) { } %>
-<%= link_to_if(next_se, 'next >', next_se) { } %>

--- a/app/views/student_exercises/feedback.html.erb
+++ b/app/views/student_exercises/feedback.html.erb
@@ -26,8 +26,4 @@
            :locals => {:response_timeable => @student_exercise,
                        :page => "feedback"} %>
 
-<% navitem{ link_to 'Show Assignment', assignment_path(@student_exercise.student_assignment.assignment) }%>
-<% content_for :other_nav_content do %>
-  Exercises
-  <%= render :partial => 'student_exercises/list', :locals => {:student_exercise => @student_exercise} %>
-<% end %>
+<%= render :partial => 'student_exercises/feedback_nav', :locals => {:student_exercise => @student_exercise} %>

--- a/app/views/student_exercises/show.html.erb
+++ b/app/views/student_exercises/show.html.erb
@@ -67,13 +67,4 @@
 
 <%= protect_form %>
 
-<% navitem{ link_to 'Show Assignment', assignment_path(@student_exercise.assignment_exercise.assignment) }%>
-
-<% content_for :other_nav_content do %>
-  Exercises
-  <%= render 'student_exercises/list', student_exercise: @student_exercise %>
-<% end %>
-
-<% content_for :other_nav_content do %>
-  <%= render 'student_exercises/nav', student_exercise: @student_exercise %>
-<% end %>
+<%= render 'student_exercises/exercise_nav', student_exercise: @student_exercise %>


### PR DESCRIPTION
This PR expands on issue #274.

On the StudentExercise show page, there are now clear links to prev and next StudentExercises as well as a link to Feedback, if it is available.

On the StudentExercise feedback page, there are now clear links to next and prev Feedbacks, as well as a link to the StudentExercise associated with the currently displayed Feedback.

On both pages, there are links back to the Class and Assignment.  The spacing between links has been adjusted to form natural groups and to avoid visual clutter.
