### PR TITLE
Removes TopexExercise name from StudentExercise nav list

### DIFF
--- a/app/views/student_exercises/_list.html.erb
+++ b/app/views/student_exercises/_list.html.erb
@@ -37,6 +37,5 @@
           <% end %>
         <% end %>
       <% end %>
-      <%= "(#{se.assignment_exercise.topic_exercise.name})" if (!Rails.env.production? && !se.assignment_exercise.topic_exercise.name.blank?) %>
 <% end %>
 </ol>


### PR DESCRIPTION
This PR removes diagnostic information in non-Production environments from the StudentExercise nav list.  The original intent of the information was to aid testing, but that feature is pretty much defunct at this point and the extra text is visually distracting.
