### PR TITLE
Suppresses SelAns confidence ratings for non-researchers

### DIFF
--- a/app/views/classes/report.xls.erb
+++ b/app/views/classes/report.xls.erb
@@ -49,7 +49,9 @@
         <%= render "report_heading_cell", data: "SelAns?",          comment: "Student locked-in a Selected Answer?" %>
         <%= render "report_heading_cell", data: "SelAnsTime",       comment: "Time at which Selected Answer was locked-in" %>
         <%= render "report_heading_cell", data: "SelAns",           comment: "Selected Answer {0 == 'a', 1 == 'b', ...}" %>
-        <%= render "report_heading_cell", data: "SelAnsConf",       comment: "Selected Answer Confidence {0 == 'Definitely Wrong, ..., 4 == 'Definitely Right'}" %>
+        <% if present_user_is_researcher %>
+          <%= render "report_heading_cell", data: "SelAnsConf",       comment: "Selected Answer Confidence {0 == 'Definitely Wrong, ..., 4 == 'Definitely Right'}" %>
+        <% end %>
         <%= render "report_heading_cell", data: "SelAnsCredit",     comment: "Selected Answer Credit [0..1]" %>
         <%= render "report_heading_cell", data: "FollowUpQ?",       comment: "Exercise had follow-up question?" %>
         <%= render "report_heading_cell", data: "FollowUpQ",        comment: "Follow-up question" %>
@@ -95,7 +97,9 @@
         <Cell><Data ss:Type="String"><%= tf_to_yn(se.selected_answer_submitted?) %></Data></Cell>
         <Cell><Data ss:Type="String"><%= se.selected_answer_submitted_at %></Data></Cell>
         <Cell><Data ss:Type="Number"><%= se.selected_answer %></Data></Cell>
-        <Cell><Data ss:Type="Number"><%= se.free_response_confidence %></Data></Cell>
+        <% if present_user_is_researcher %>
+          <Cell><Data ss:Type="Number"><%= se.free_response_confidence %></Data></Cell>
+        <% end %>
         <Cell><Data ss:Type="Number"><%= se.automated_credit %></Data></Cell>
         <Cell><Data ss:Type="String"><%= tf_to_yn(se.requires_follow_up_question?) %></Data></Cell>
         <Cell><Data ss:Type="String"><%= se.follow_up_question %></Data></Cell>

--- a/app/views/student_assignments/show.html.erb
+++ b/app/views/student_assignments/show.html.erb
@@ -14,8 +14,7 @@
   <table class="list" width="90%">
     <tr>
       <th width="3%">#</th>
-      <th width="58%">Response</th>
-      <th width="8%">Conf<br/>(0-4)</th>
+      <th width="66%">Response</th>
       <th width="8%">Choice</th>
       <th width="8%">Score</th>
       <th width="8%">Times</th>
@@ -39,7 +38,6 @@
             </div>
           <% end %>
         </td>
-        <td><%= se.free_response_confidence.nil? ? "--" : se.free_response_confidence %></td>
         <td><%= se.selected_answer.nil? ? "--" : "(#{choice_letter(se.selected_answer)})" %></td>
         <td><%= link_to se.score, student_exercise_score_detail_path(se), :remote => true %></td>
         <td>


### PR DESCRIPTION
This PR should resolve issue #276.

The `Conf` column has been removed from the StudentAssignment show page, and the `SelAnsConf` column is now present in the report.xls spreadsheet only if the current user is a Researcher.
