### PR TITLE
Updates to Educator and Grader permissions

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -90,7 +90,7 @@ class Assignment < ActiveRecord::Base
   def children_can_be_read_by?(user, children_symbol)
     case children_symbol
     when :grades
-      cohort.klass.is_teacher?(user) || user.is_researcher? || user.is_administrator?
+      cohort.klass.is_educator?(user) || user.is_researcher? || user.is_administrator?
     end
   end
 

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -218,17 +218,17 @@ class Klass < ActiveRecord::Base
   def children_can_be_read_by?(user, children_symbol)
     case children_symbol
     when :sections
-      is_teacher?(user) || user.is_administrator?
+      is_educator?(user) || user.is_administrator?
     when :cohorts
       (is_controlled_experiment ? Researcher.is_one?(user) : is_teaching_assistant?(user)) || user.is_administrator?
     when :learning_conditions # not a direct child
       (is_controlled_experiment ? Researcher.is_one?(user) : is_instructor?(user)) || user.is_administrator?
     when :students
-      is_teacher?(user) || user.is_researcher? || user.is_administrator?
+      is_educator?(user) || user.is_researcher? || user.is_administrator?
     when :report
       is_teacher?(user) || user.is_researcher? || user.is_administrator?
     when :class_grades
-      is_teacher?(user) || user.is_researcher? || user.is_administrator?
+      is_educator?(user) || user.is_researcher? || user.is_administrator?
     when :analytics 
       is_teacher?(user) || is_student?(user) || user.is_administrator?
     end

--- a/app/models/learning_plan.rb
+++ b/app/models/learning_plan.rb
@@ -35,7 +35,7 @@ class LearningPlan < ActiveRecord::Base
   #############################################################################
   
   def can_be_read_by?(user)
-    klass.is_teaching_assistant?(user) || user.is_researcher? || user.is_administrator?
+    klass.is_educator?(user) || user.is_researcher? || user.is_administrator?
   end
     
   def can_be_created_by?(user)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -37,7 +37,7 @@ class Section < ActiveRecord::Base
   def children_can_be_read_by?(user, children_symbol)
     case children_symbol
     when :students
-      !user.is_anonymous? && (klass.is_teacher?(user) || Researcher.is_one?(user) || user.is_administrator?)
+      !user.is_anonymous? && (klass.is_educator?(user) || Researcher.is_one?(user) || user.is_administrator?)
     else
       false
     end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -125,7 +125,7 @@ class Student < ActiveRecord::Base
   #############################################################################
 
   def can_be_read_by?(user)
-    user.id == user_id || section.klass.is_teacher?(user) || Researcher.is_one?(user) || user.is_administrator?
+    user.id == user_id || section.klass.is_educator?(user) || Researcher.is_one?(user) || user.is_administrator?
   end
 
   def can_be_updated_by?(user)
@@ -135,7 +135,7 @@ class Student < ActiveRecord::Base
   def children_can_be_read_by?(user, children_symbol)
     case children_symbol
     when :student_assignments
-      return section.klass.is_teacher?(user) || Researcher.is_one?(user) || user.is_administrator?
+      return section.klass.is_educator?(user) || Researcher.is_one?(user) || user.is_administrator?
     end
     false
   end

--- a/app/models/student_assignment.rb
+++ b/app/models/student_assignment.rb
@@ -105,7 +105,7 @@ class StudentAssignment < ActiveRecord::Base
   #############################################################################
       
   def can_be_read_by?(user)
-    !user.is_anonymous? && (student.section.klass.is_teacher?(user) || (user.is_researcher? && student.consented?)) || user.is_administrator?
+    !user.is_anonymous? && (student.section.klass.is_educator?(user) || (user.is_researcher? && student.consented?)) || user.is_administrator?
   end
       
   def can_be_created_by?(user)

--- a/app/models/student_exercise.rb
+++ b/app/models/student_exercise.rb
@@ -214,7 +214,7 @@ class StudentExercise < ActiveRecord::Base
   def can_be_read_by?(user)
     return false          if user.is_anonymous?
     return !klass.closed? if belongs_to_active_student_user?(user)
-    return true           if is_teacher?(user)
+    return true           if is_educator?(user)
     return true           if user.is_administrator?
     return false
   end
@@ -227,7 +227,7 @@ class StudentExercise < ActiveRecord::Base
 
   def can_be_changed_by?(user)
     return false if user.is_anonymous?
-    return true  if is_teacher?(user)
+    return true  if is_educator?(user)
     return true  if user.is_administrator?
     return false
   end
@@ -242,8 +242,16 @@ class StudentExercise < ActiveRecord::Base
     belongs_to_student_user?(user) && student_assignment.student.active?
   end
   
+  def klass
+    student_assignment.student.section.klass
+  end
+
   def is_teacher?(user)
-    student_assignment.student.section.klass.is_teacher?(user)
+    klass.is_teacher?(user)
+  end
+
+  def is_educator?(user)
+    klass.is_educator?(user)
   end
 
   def destroyable?

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -95,7 +95,7 @@
 
 <% end %>
 
-<% if klass.is_teacher?(present_user) || Researcher.is_one?(present_user) || present_user.is_administrator? %>
+<% if klass.is_educator?(present_user) || Researcher.is_one?(present_user) || present_user.is_administrator? %>
   <%= render 'results', :assignment_plan => assignment_plan %>
 <% end %>
 

--- a/app/views/classes/preview_assignments.html.erb
+++ b/app/views/classes/preview_assignments.html.erb
@@ -25,7 +25,7 @@
             <li class="test test_section"><%= link_to "#{te.display_name}", exercise.url %> 
                 [<%= te.topic.name %> / 
                  <%= te.concept.try(:name) || 'no concept' %>
-                 <% if present_user.is_researcher? || present_user.is_administrator? %> 
+                 <% if present_user.is_researcher? || present_user.is_administrator? || !assignment.klass.is_controlled_experiment %> 
                    / <%= ae.tag_list %>
                  <% end %>
                 ]

--- a/app/views/classes/show.html.erb
+++ b/app/views/classes/show.html.erb
@@ -7,6 +7,7 @@
 
 <% 
   is_teacher = @klass.is_teacher?(present_user)
+  is_educator = @klass.is_educator?(present_user)
   student = @klass.student_for(present_user) 
   is_student = !student.nil?
   student_cohort = student.try(:cohort)
@@ -180,7 +181,7 @@
 
 <% end %>
 
-<% sees_all_cohort_assignments = is_teacher || present_user.is_researcher? || present_user.is_administrator? %>
+<% sees_all_cohort_assignments = is_educator || present_user.is_researcher? || present_user.is_administrator? %>
 
 <%= section "Registration Status", {:classes => "registration_status"} do %>
   <% if is_student %>


### PR DESCRIPTION
This should resolve issues #275 and #271.

All uses of `Klass.is_educator?(user)` were replaced with `Klass.is_teacher?(user)`, a new method which returns true only if the user is an Instructor or a TeachingAssistant.  This should preserve all existing behaviors since there were no Graders in the system at the time of the change.

Uses of `is_teacher?(user)` were changed as needed by Graders to do their job, thus limiting the scope of their powers to the absolute minimum (hopefully).

Another minor change was to allow Educators to see Assignment labels when the associated Class is not part of a controlled experiment.
