### PR TITLE
Fixes mailhook missing subject exceptions

### DIFF
--- a/app/models/mail_hook.rb
+++ b/app/models/mail_hook.rb
@@ -106,7 +106,7 @@ protected
   def self.get_mail_fields(mail)
     to_addresses = [mail.to].flatten.collect{|to| to.downcase}
     # Get rid of non word characters and strip whitespace
-    subject = mail.subject.downcase.gsub(/[^a-z\s^A-Z\s]/,"").strip
+    subject = (mail.subject || "").downcase.gsub(/[^a-z\s^A-Z\s]/,"").strip
     [to_addresses, subject]
   end
 


### PR DESCRIPTION
This PR should prevent subject-less emails from causing the following MailHook exception:

Exception Encountered

Error ID: 557809

User ID: 
Username: anonymous

URL: https://openstaxtutor.org/mail_hooks/catch

Message: N/A

Exception: #<NoMethodError: undefined method `downcase' for nil:NilClass>

Backtrace:

app/models/mail_hook.rb:109:in `get_mail_fields'
app/models/mail_hook.rb:56:in`matches_for'
app/models/mail_hook.rb:67:in `process'
app/controllers/mail_hooks_controller.rb:12:in`catch'
