### PR TITLE
Makes PresentationCondition and FeedbackCondition regexps case-insensitive

### DIFF
--- a/app/models/basic_feedback_condition.rb
+++ b/app/models/basic_feedback_condition.rb
@@ -103,7 +103,7 @@ class BasicFeedbackCondition < FeedbackCondition
 
     label_regex_array.any? do |regex|
       labels.any? do |label|
-        label == regex || label.match(regex)
+        label == regex || label.match(Regexp.new(regex, Regexp::IGNORECASE))
       end
     end    
   end

--- a/app/models/presentation_condition.rb
+++ b/app/models/presentation_condition.rb
@@ -36,7 +36,7 @@ class PresentationCondition < ActiveRecord::Base
 
     label_regex_array.any? do |regex|
       labels.any? do |label|
-        label == regex || label.match(regex)
+        label == regex || label.match(Regexp.new(regex, Regexp::IGNORECASE))
       end
     end
   end

--- a/app/views/basic_feedback_conditions/_form.html.erb
+++ b/app/views/basic_feedback_conditions/_form.html.erb
@@ -18,7 +18,7 @@
   <%= hidden_field_tag :type, 'BasicFeedbackCondition' %>
   
   <div class="field">
-    Match Labels Against: <%= link_to_help 'labels' %>
+    Match Labels Against <%= link_to_help 'labels' %> <i>(comparisons are automatically made case-insensitive)</i>:<br/>
     <%= f.text_field :label_regex %>
   </div>
   <div class="field">

--- a/app/views/presentation_conditions/_form.html.erb
+++ b/app/views/presentation_conditions/_form.html.erb
@@ -13,7 +13,7 @@
       <%= link_to "Learn more.", help_learning_conditions_path, :target => '_blank' %></p>
 
   <div class="field">
-    Match Labels Against <%= link_to_help 'presentation_labels' %>:
+    Match Labels Against <%= link_to_help 'presentation_labels' %> <i>(comparisons are automatically made case-insensitive)</i>:<br/>
     <%= f.text_field :label_regex %>
   </div>
 


### PR DESCRIPTION
This PR will help prevent users from accidentally failing to match their PCs and FCs due to case.

Anywhere the user enters a label (aka 'tag') in a form, it is internally converted to lowercase:

``` ruby
ActsAsTaggableOn.force_lowercase = true
```

but the string displayed to the user is not.  This causes user confusion when forming PC and FC regexps, since they are unaware of the internal change.  To mitigate this problem, the regexps used in PC and FC matching are made case-insensitive:

``` ruby
label == regex || label.match(Regexp.new(regex, Regexp::IGNORECASE))
```
