### PR TITLE
Adds Class Management Overview display (Admin and Researcher only)

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -669,6 +669,11 @@ table.left_heading th, td {
 	padding-bottom: 3px;
 }
 
+table.klass_management_overview th, td {
+  padding-left:  5px;
+  padding-right: 5px;
+}
+
 .left_heading_offset {
 	margin-left:40px; 
 	margin-right:150px;

--- a/app/controllers/classes_controller.rb
+++ b/app/controllers/classes_controller.rb
@@ -132,7 +132,13 @@ class ClassesController < ApplicationController
       format.xls
     end
   end
-    
+
+  def management_overview
+    @klass = Klass.find(params[:id])
+
+    raise SecurityTransgression unless present_user.can_read_children?(@klass, :management_overview)
+  end
+
 protected
 
   def get_course

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -554,14 +554,26 @@ module ApplicationHelper
     "REGISTERED"
   end
 
+  def student_status_string_short_registered
+    "REG"
+  end
+
   def student_status_string_auditing
     "AUDITING"
+  end
+
+  def student_status_string_short_auditing
+    "AUD"
   end
 
   def student_status_string_dropped
     "DROPPED"
   end
-  
+
+  def student_status_string_short_dropped
+    "DRP"
+  end
+
   def student_status_strings
     [student_status_string_registered, student_status_string_auditing, student_status_string_dropped]
   end
@@ -573,6 +585,16 @@ module ApplicationHelper
       student_status_string_auditing
     else
       student_status_string_registered
+    end
+  end
+
+  def student_status_string_short(student)
+    if student.has_dropped?
+      student_status_string_short_dropped
+    elsif student.auditing?
+      student_status_string_short_auditing
+    else
+      student_status_string_short_registered
     end
   end
 

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -231,6 +231,8 @@ class Klass < ActiveRecord::Base
       is_educator?(user) || user.is_researcher? || user.is_administrator?
     when :analytics 
       is_teacher?(user) || is_student?(user) || user.is_administrator?
+    when :management_overview
+      user.is_researcher? || user.is_administrator?
     end
   end
 

--- a/app/views/classes/management_overview.html.erb
+++ b/app/views/classes/management_overview.html.erb
@@ -1,0 +1,48 @@
+<% user_is_researcher = present_user.is_researcher? %>
+<% user_is_visitor    = present_user.is_visitor? %>
+
+<% registration_status_sort_order = [ student_status_string_short_registered,
+                                      student_status_string_short_auditing,
+                                      student_status_string_short_dropped ] %>
+
+<%
+  students = @klass.students.visible(present_user).sort_by do |student|
+    [
+      student.section.klass.sections.index(student.section),
+      student.cohort.number,
+      registration_status_sort_order.index(student_status_string_short(student)),
+      (user_is_researcher || user_is_visitor) ? student.user.research_id : "#{student.user.last_name} #{student.user.first_name}".downcase
+    ]
+  end
+%>
+
+<%= pageHeading "Class Management Overview: #{@klass.course.name}" %>
+
+<div>
+
+  <table class="list klass_management_overview" width="100%">
+  <tr>
+    <th width="20%">Student Section</th>
+    <th width="20%">Cohort Section</th>
+    <th width="20%">Cohort</th>
+    <th width="10%">RS</th>
+    <th width="30%">Student</th>
+  </tr>
+  <% students.each do |student| %>
+    <tr>
+      <td><%= student.section.name %></td>
+      <td><%= student.cohort.section.nil? ? "" : student.cohort.section.name %></td>
+      <td><%= student.cohort.name %></td>
+      <td><%= student_status_string_short(student) %></td>
+      <td><%= link_to_if(present_user.can_read?(student), student.full_name(present_user), student) %></td>
+    </tr>
+  <% end %>
+  </table>
+
+</div>
+
+<%
+  navitem(present_user.can_read?(@klass)) { link_to('Back to Class', klass_path(@klass)) }
+  navitem(:can_read_children?, @klass, :sections) { link_to("Sections", klass_sections_path(@klass)) }
+  navitem(:can_read_children?, @klass, :cohorts) { link_to("Cohorts", klass_cohorts_path(@klass)) }
+%>

--- a/app/views/classes/show.html.erb
+++ b/app/views/classes/show.html.erb
@@ -220,6 +220,7 @@
   @force_nav_bar = true;
   navitem(present_user.can_update?(@klass)) { link_to('Edit Class', edit_klass_path(@klass)) }
   navitem(:can_read?, @klass.learning_plan) { link_to("Learning Plan", @klass.learning_plan) }
+  navitem(:can_read_children?, @klass, :management_overview) { link_to("Management Overview", management_overview_klass_path(@klass)) }
   navitem(:can_read_children?, @klass, :sections) { link_to("Sections", klass_sections_path(@klass)) }
   navitem(:can_read_children?, @klass, :learning_conditions) { link_to("Learning Conditions", klass_learning_conditions_path(@klass)) }
   navitem(:can_read_children?, @klass, :cohorts) { link_to("Cohorts", klass_cohorts_path(@klass)) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Ost::Application.routes.draw do
     get 'preview_assignments', :on => :member
     get 'report', :on => :member
     get 'class_grades', :on => :member
+    get 'management_overview', :on => :member
   end
   
   resources :learning_conditions, :only => [] do


### PR DESCRIPTION
This PR provides admins and researchers a "Management Overview" link from the Class Show Page.  The overview  is a table showing the connections between Students, Cohorts, and Sections.

The list of Students and their display names are filtered according to the type of User (admin vs researcher).
