### PR TITLE
Shortens index names longer than 50 characters

### DIFF
--- a/db/migrate/20130907030901_shorten_index_names.rb
+++ b/db/migrate/20130907030901_shorten_index_names.rb
@@ -1,0 +1,11 @@
+class ShortenIndexNames < ActiveRecord::Migration
+  def change
+    rename_index :taggings,                "index_taggings_on_taggable_id_and_taggable_type_and_context", "index_taggings_on_taggable_id_type_context"
+    rename_index :presentation_conditions, "index_presentation_conditions_on_learning_condition_id",      "index_pcs_on_lc_id"
+    rename_index :presentation_conditions, "index_presentation_condition_on_number_scoped",               "index_pcs_on_number_scoped"
+    rename_index :assignment_coworkers,    "index_assignment_coworkers_on_student_assignment_id",         "index_assignment_cws_on_sa_id"
+    rename_index :feedback_conditions,     "index_feedback_conditions_on_learning_condition_id",          "index_fcs_on_lc_id"
+    rename_index :assignment_plan_topics,  "index_assignment_plan_topics_on_assignment_plan_id",          "index_apts_on_ap_id"
+    rename_index :assignment_exercises,    "index_assignment_exercises_on_topic_exercise_id_scoped",      "index_aes_on_te_id_scoped"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130904230948) do
+ActiveRecord::Schema.define(:version => 20130907030901) do
 
   create_table "assignment_coworkers", :force => true do |t|
     t.integer  "student_assignment_id"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(:version => 20130904230948) do
     t.datetime "updated_at",            :null => false
   end
 
-  add_index "assignment_coworkers", ["student_assignment_id"], :name => "index_assignment_coworkers_on_student_assignment_id"
+  add_index "assignment_coworkers", ["student_assignment_id"], :name => "index_assignment_cws_on_sa_id"
   add_index "assignment_coworkers", ["student_id", "student_assignment_id"], :name => "index_assignment_coworkers_on_student_id_scoped", :unique => true
   add_index "assignment_coworkers", ["student_id"], :name => "index_assignment_coworkers_on_student_id"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(:version => 20130904230948) do
 
   add_index "assignment_exercises", ["assignment_id"], :name => "index_assignment_exercises_on_assignment_id"
   add_index "assignment_exercises", ["number", "assignment_id"], :name => "index_assignment_exercises_on_number_scoped", :unique => true
-  add_index "assignment_exercises", ["topic_exercise_id", "assignment_id"], :name => "index_assignment_exercises_on_topic_exercise_id_scoped", :unique => true
+  add_index "assignment_exercises", ["topic_exercise_id", "assignment_id"], :name => "index_aes_on_te_id_scoped", :unique => true
   add_index "assignment_exercises", ["topic_exercise_id"], :name => "index_assignment_exercises_on_topic_exercise_id"
 
   create_table "assignment_plan_topics", :force => true do |t|
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(:version => 20130904230948) do
     t.boolean  "hide_resources",       :default => false
   end
 
-  add_index "assignment_plan_topics", ["assignment_plan_id"], :name => "index_assignment_plan_topics_on_assignment_plan_id"
+  add_index "assignment_plan_topics", ["assignment_plan_id"], :name => "index_apts_on_ap_id"
   add_index "assignment_plan_topics", ["topic_id"], :name => "index_assignment_plan_topics_on_topic_id"
 
   create_table "assignment_plans", :force => true do |t|
@@ -201,7 +201,7 @@ ActiveRecord::Schema.define(:version => 20130904230948) do
     t.datetime "updated_at",            :null => false
   end
 
-  add_index "feedback_conditions", ["learning_condition_id"], :name => "index_feedback_conditions_on_learning_condition_id"
+  add_index "feedback_conditions", ["learning_condition_id"], :name => "index_fcs_on_lc_id"
   add_index "feedback_conditions", ["number", "learning_condition_id"], :name => "index_feedback_conditions_on_number_scoped", :unique => true
 
   create_table "free_responses", :force => true do |t|
@@ -298,8 +298,8 @@ ActiveRecord::Schema.define(:version => 20130904230948) do
     t.boolean  "apply_follow_up_question_to_tests", :default => false
   end
 
-  add_index "presentation_conditions", ["learning_condition_id"], :name => "index_presentation_conditions_on_learning_condition_id"
-  add_index "presentation_conditions", ["number", "learning_condition_id"], :name => "index_presentation_condition_on_number_scoped", :unique => true
+  add_index "presentation_conditions", ["learning_condition_id"], :name => "index_pcs_on_lc_id"
+  add_index "presentation_conditions", ["number", "learning_condition_id"], :name => "index_pcs_on_number_scoped", :unique => true
 
   create_table "registration_requests", :force => true do |t|
     t.integer  "user_id",                            :null => false
@@ -448,7 +448,7 @@ ActiveRecord::Schema.define(:version => 20130904230948) do
   end
 
   add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_type_context"
 
   create_table "tags", :force => true do |t|
     t.string "name"


### PR DESCRIPTION
This PR shortens all index names longer than 50 characters.  The long names have been causing problems with database migrations because rails creates temporary table names whose associated index names exceed the 64 character limit in some cases.
