### PR TITLE
Adds diagnostic info for assignment preview page

### DIFF
--- a/app/models/basic_feedback_condition.rb
+++ b/app/models/basic_feedback_condition.rb
@@ -97,15 +97,22 @@ class BasicFeedbackCondition < FeedbackCondition
                                :show_detailed_feedback          => false)
   end
 
-  def applies_to?(student_exercise)
+  def applies_to?(student_or_assignment_exercise)
     label_regex_array = label_regex.split(",").collect{|lr| lr.strip}
-    labels = student_exercise.assignment_exercise.tag_list
+
+    if student_or_assignment_exercise.instance_of? StudentExercise
+      assignment_exercise = student_or_assignment_exercise.assignment_exercise
+    else
+      assignment_exercise = student_or_assignment_exercise
+    end
+
+    labels = assignment_exercise.tag_list
 
     label_regex_array.any? do |regex|
       labels.any? do |label|
         label == regex || label.match(Regexp.new(regex, Regexp::IGNORECASE))
       end
-    end    
+    end
   end
   
   def can_automatically_show_feedback?(student_exercise)

--- a/app/models/learning_condition.rb
+++ b/app/models/learning_condition.rb
@@ -121,18 +121,16 @@ class LearningCondition < ActiveRecord::Base
       Researcher.is_one?(user) || user.is_administrator? :
       cohort.klass.is_instructor?(user) || user.is_administrator?
   end
-  
+
+  def get_presentation_condition(student_or_assignment_exercise)
+    presentation_conditions.detect{ |pc| pc.applies_to?(student_or_assignment_exercise) } || PresentationCondition.default_presentation_condition
+  end
+
+  def get_feedback_condition(student_or_assignment_exercise)
+    feedback_conditions.detect{ |fc| fc.applies_to?(student_or_assignment_exercise) } || BasicFeedbackCondition.default_feedback_condition
+  end
+
 protected
-
-  def get_presentation_condition(student_exercise)
-    @presentation_conditions ||= {}
-    @presentation_conditions[student_exercise.id] ||= presentation_conditions.detect{ |pc| pc.applies_to?(student_exercise) } || PresentationCondition.default_presentation_condition
-  end
-
-  def get_feedback_condition(student_exercise)
-    @feedback_conditions ||= {}
-    @feedback_conditions[student_exercise.id] ||= feedback_conditions.detect{ |fc| fc.applies_to?(student_exercise) } || BasicFeedbackCondition.default_feedback_condition
-  end
 
   def show_student_assignment_correctness_feedback?(student_assignment)
     student_assignment.student_exercises.inject(true) { |result, se| result && show_student_exercise_correctness_feedback?(se) }

--- a/app/models/presentation_condition.rb
+++ b/app/models/presentation_condition.rb
@@ -30,9 +30,16 @@ class PresentationCondition < ActiveRecord::Base
                               :requires_selected_answer => true)
   end
 
-  def applies_to?(student_exercise)
+  def applies_to?(student_or_assignment_exercise)
     label_regex_array = label_regex.split(",").collect{|lr| lr.strip}
-    labels = student_exercise.assignment_exercise.tag_list
+
+    if student_or_assignment_exercise.instance_of? StudentExercise
+      assignment_exercise = student_or_assignment_exercise.assignment_exercise
+    else
+      assignment_exercise = student_or_assignment_exercise
+    end
+
+    labels = assignment_exercise.tag_list
 
     label_regex_array.any? do |regex|
       labels.any? do |label|

--- a/app/views/basic_feedback_conditions/_show.html.erb
+++ b/app/views/basic_feedback_conditions/_show.html.erb
@@ -3,6 +3,7 @@
 
 <% assignment_event = BasicFeedbackCondition::AvailabilityEvent[feedback_condition.availability_event].to_s.humanize.downcase %>
 <ul>
+  <li>Id: <%= feedback_condition.id || "N/A" %></li>
   <li>Matches labels against: <%= feedback_condition.label_regex || "[Not set]" %></li>
   <li>Feedback viewing is required?: <%= tf_to_yn(feedback_condition.is_feedback_required_for_credit) %></li>
   <li>Can automatically show feedback?: <%= tf_to_yn(feedback_condition.can_automatically_show_feedback) %></li>

--- a/app/views/classes/_preview_cohort_assignment.html.erb
+++ b/app/views/classes/_preview_cohort_assignment.html.erb
@@ -1,0 +1,47 @@
+<% present_user_can_see_tag_lists = present_user.is_researcher? ||
+                                    present_user.is_administrator? ||
+                                    !assignment.klass.is_controlled_experiment %>
+
+<table class="list preview_cohort_assignment" style="width:1325px;table-layout:fixed">
+  <tr>
+    <th width="025px">#</th>
+    <th width="100px">Ex</th>
+    <th width="200px">Topic</th>
+    <th width="200px">Concept</th>
+    <th width="300px">Ex Labels</th>
+    <th width="050px">PC Id</th>
+    <th width="200px">PC Regex</th>
+    <th width="050px">FC Id</th>
+    <th width="200px">FC Regex</th>
+  </tr>
+
+  <% assignment.assignment_exercises.each_with_index do |ae, ae_index| %>
+    <%
+      te = ae.topic_exercise
+      ex = te.exercise
+      lc = cohort.learning_condition
+      pc = lc.get_presentation_condition(ae)
+      fc = lc.get_feedback_condition(ae)
+    %>
+    <tr>
+      <td><%= 1 + ae_index %></td>
+      <td><%= link_to "#{te.display_name}", ex.url %></td>
+      <td><%= te.topic.name %></td>
+      <td><%= te.concept.try(:name) || "N/A" %></td>
+
+      <% if present_user_can_see_tag_lists %>
+        <td><%= present_user_can_see_tag_lists ? ae.tag_list.join(", ") : "N/A" %></td>
+        <td><%= pc.id.nil? ? '--' : link_to_if(present_user.can_update?(pc), pc.id, edit_presentation_condition_path(pc)) %></td>
+        <td><%= pc.label_regex %></td>
+        <td><%= fc.id.nil? ? '--' : link_to_if(present_user.can_update?(fc), fc.id, edit_feedback_condition_path(fc)) %></td>
+        <td><%= fc.label_regex %></td>
+      <% else %>
+        <td>N/A</td>
+        <td>N/A</td>
+        <td>N/A</td>
+        <td>N/A</td>
+        <td>N/A</td>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/classes/preview_assignments.html.erb
+++ b/app/views/classes/preview_assignments.html.erb
@@ -5,38 +5,28 @@
 <% addTestMeta {{:major_name => @klass.course.name}} %>
 <% addTestMeta {{:minor_name => "Learning Plan"}} %>
 
-<%= pageHeading "Preview of Assignments" %>
+<%= pageHeading "Preview of Assignments: #{@klass.course.name}" %>
 
 <% @assignments.each_with_index do |assignment_array, ii| %>
   
   <% next if assignment_array.empty? %>
   
-  <%= section "#{assignment_array[0].assignment_plan.name}", {:classes => "#{ii == 0 ? 'first no_bar' : ''}" } do %>
+  <%= section "Assignment: #{assignment_array[0].assignment_plan.name}", {:classes => "#{ii == 0 ? 'first no_bar' : ''}" } do %>
     
     <% assignment_array.each do |assignment| %>
       <% cohort = assignment.cohort %>
     
       <div class="test test_section cohort">
-        <p><b>Cohort: <%= cohort.name %> <%= ", Section: #{cohort.section.name}" if !cohort.section_id.nil? %></b></p>
-        <ol>
-          <% assignment.assignment_exercises.each do |ae| %>
-            <% te = ae.topic_exercise %>
-            <% exercise = te.exercise %>
-            <li class="test test_section"><%= link_to "#{te.display_name}", exercise.url %> 
-                [<%= te.topic.name %> / 
-                 <%= te.concept.try(:name) || 'no concept' %>
-                 <% if present_user.is_researcher? || present_user.is_administrator? || !assignment.klass.is_controlled_experiment %> 
-                   / <%= ae.tag_list %>
-                 <% end %>
-                ]
-            </li>
-          <% end %>
-        </ol>
+        <p><b>Cohort: <%= cohort.name %>, Cohort Section: <%= cohort.section.nil? ? "N/A" : cohort.section.name %></b></p>
+        <% if assignment.assignment_exercises.any? %>
+          <%= render partial: "preview_cohort_assignment", locals: { cohort: cohort, assignment: assignment } %>
+        <% else %>
+          <p>No assignment exercises.</p>
+        <% end %>
       </div>
 
     <% end %>
   
   <% end %>
-  
   
 <% end %>

--- a/app/views/classes/show.html.erb
+++ b/app/views/classes/show.html.erb
@@ -5,6 +5,8 @@
 <% addTestMeta {{:major_name => @klass.course.organization.name}} %>
 <% addTestMeta {{:minor_name => @klass.course.name}} %>
 
+<%= pageHeading "Class: #{@klass.course.name}"%>
+
 <% 
   is_teacher = @klass.is_teacher?(present_user)
   is_educator = @klass.is_educator?(present_user)

--- a/app/views/learning_conditions/index.html.erb
+++ b/app/views/learning_conditions/index.html.erb
@@ -1,7 +1,7 @@
 <%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<%= pageHeading "Learning Conditions" %>
+<%= pageHeading "Learning Conditions: #{@klass.course.name}" %>
 
 <p>Learning conditions are customizable rules that enable you to customize your 
 	students' experiences using <%= SITE_NAME %>. <u>Before</u> releasing any assignments, 

--- a/app/views/presentation_conditions/_show.html.erb
+++ b/app/views/presentation_conditions/_show.html.erb
@@ -2,6 +2,7 @@
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 <ul>
+  <li>Id: <%= presentation_condition.id || "N/A" %></li>
   <li>Matches labels against: <%= presentation_condition.label_regex || "[Not set]" %></li>
   <li>Require free-response?: <%= tf_to_yn(presentation_condition.requires_free_response?) %></li>
   <li>Require selected answer?: <%= tf_to_yn(presentation_condition.requires_selected_answer?) %></li>


### PR DESCRIPTION
This PR adds PresentationCondition- and FeedbackCondition-related diagnostic information to the Assignment Preview page.

The following table is displayed per AssignmentPlan and Cohort:
![screen shot 2013-09-10 at 8 58 53 pm](https://f.cloud.github.com/assets/1851667/1120206/91cf22dc-1a96-11e3-8d81-e37b0a508d49.png)

The `Ex Labels`, `PC Id`, `PC Regex`, `FC Id`, and `FC Regex` columns are populated with `N/A` if the current user is not an Admin or Researcher or if the klass is not part of a controlled experiment.  The table is too wide to display effectively on narrow screens, so some horizontal scrolling will be needed for users working on laptops, etc.

On the LearningConditions page, the IDs for the LC's PCs/FCs are listed along with their other properties, making it easy to correlate information between the LearningConditions page and the Assignment Preview page.

The LC's `get_{presentation,feedback}_conditions` methods have been moved from `protected` to `private` to allow them to be called from other classes.  This will be used extensively in upcoming PRs.  Also, the `applies_to?` methods on PresentationCondition and BasicFeedbackCondition have been tweaked to accept either a StudentExercise or and AssignmentExercise.  This will greatly simplify code in other parts of the system (like reports).

There are also some minor tweaks to the page headings for other Klass-related pages, mostly to make it easier to find the appropriate tab in a browser.
