### PR TITLE
Fixes crash due to missing helper function

### DIFF
--- a/app/mailers/site_mailer.rb
+++ b/app/mailers/site_mailer.rb
@@ -3,7 +3,9 @@
 
 class SiteMailer < ActionMailer::Base
   include Ost::Utilities
-    
+  
+  helper :application
+
   default :from => "noreply@openstaxtutor.org"
 
   def mail(headers={}, &block)


### PR DESCRIPTION
This PR corrects a crash inside the DeveloperNotifier, preventing emails from going out when OST exceptions occur.
