### PR TITLE
Fixes before_destroy ordering and association caching issues

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -18,7 +18,7 @@ class Assignment < ActiveRecord::Base
   
   accepts_nested_attributes_for :assignment_exercises
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   attr_accessor :dry_run
   
@@ -48,7 +48,7 @@ class Assignment < ActiveRecord::Base
   end
   
   def assigned?
-    student_assignments.any?
+    student_assignments(true).any?
   end
 
   def active?

--- a/app/models/assignment_exercise.rb
+++ b/app/models/assignment_exercise.rb
@@ -14,7 +14,7 @@ class AssignmentExercise < ActiveRecord::Base
   validates :assignment_id, :presence => true, :on => :update
   validates :topic_exercise_id, :presence => true, :uniqueness => {:scope => :assignment_id}
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   acts_as_numberable :container => :assignment
   
@@ -23,7 +23,7 @@ class AssignmentExercise < ActiveRecord::Base
   def destroyable?
     return true if sudo_enabled?
     errors.add(:base, "This assignment exercise cannot be deleted because it has already been distributed to students (except by admin override)") \
-      if student_exercises.any?
+      if student_exercises(true).any?
     errors.none?
   end
   

--- a/app/models/assignment_plan.rb
+++ b/app/models/assignment_plan.rb
@@ -12,9 +12,8 @@ class AssignmentPlan < ActiveRecord::Base
 
   before_save :add_new_exercise_tags
 
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
 
-  
   attr_accessible :introduction, :is_group_work_allowed, :is_open_book, 
                   :is_ready, :is_test, :learning_plan_id, :name, :learning_plan,
                   :starts_at, :ends_at, :section_id, :tag_list
@@ -116,7 +115,7 @@ class AssignmentPlan < ActiveRecord::Base
   end
   
   def assigned?
-    assignments.any?
+    assignments(true).any?
     # assignments.any?{|a| a.assigned?}
   end
   

--- a/app/models/assignment_plan_topic.rb
+++ b/app/models/assignment_plan_topic.rb
@@ -10,7 +10,7 @@ class AssignmentPlanTopic < ActiveRecord::Base
   
   attr_accessible :assignment_plan, :topic_id, :num_exercises_to_use, :hide_resources
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   scope :resources_visible, where(:hide_resources => false)
     
@@ -18,7 +18,7 @@ class AssignmentPlanTopic < ActiveRecord::Base
   
   def destroyable?
     self.errors.add(:base, "This topic cannot be removed from its assignment because the assignment has been issued.") \
-      if assignment_plan.assigned?
+      if assignment_plan(true).assigned?
     self.errors.none?
   end
   

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -13,7 +13,7 @@ class Cohort < ActiveRecord::Base
   validate :klass_unchanged?, :on => :update
 
   before_create :init_learning_condition
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   acts_as_numberable :container => :klass
   
@@ -93,8 +93,8 @@ class Cohort < ActiveRecord::Base
 protected
 
   def destroyable?
-    errors.add(:base, "Cannot delete this cohort because it has students") if students.any?
-    errors.add(:base, "Cannot delete this cohort because it has assignments") if assignments.any?
+    errors.add(:base, "Cannot delete this cohort because it has students") if students(true).any?
+    errors.add(:base, "Cannot delete this cohort because it has assignments") if assignments(true).any?
     errors.none?
   end
   

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -10,12 +10,12 @@ class Concept < ActiveRecord::Base
   
   acts_as_numberable :container => :learning_plan
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   attr_accessible :name, :learning_plan
   
   def destroyable?
-    return true if topic_exercises.none?
+    return true if topic_exercises(true).none?
     errors.add(:base, "This concept cannot be deleted because it is attached to exercises.")
     false
   end

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -18,7 +18,7 @@ class Klass < ActiveRecord::Base
   validates :time_zone, :presence => true
   validate :is_controlled_experiment_change_ok?, :on => :update
 
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   before_create :set_first_instructor
   before_create :init_learning_plan
   before_create :init_first_section
@@ -240,7 +240,7 @@ protected
 
   def destroyable?
     return true if sudo_enabled?
-    errors.add(:base, "This class cannot be deleted because it has sections (except by admin override).") if sections.any?
+    errors.add(:base, "This class cannot be deleted because it has sections (except by admin override).") if sections(true).any?
     errors.none?
   end
 

--- a/app/models/learning_plan.rb
+++ b/app/models/learning_plan.rb
@@ -13,7 +13,7 @@ class LearningPlan < ActiveRecord::Base
   validates :test_exercise_tags,    :tag_list_format => true
   validates :nontest_exercise_tags, :tag_list_format => true
 
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   attr_accessible :description, :name,
                   :test_exercise_tags, :nontest_exercise_tags

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,7 +7,7 @@ class Organization < ActiveRecord::Base
   
   validates :name, :presence => true, :uniqueness => true
 
-  before_destroy :assert_no_courses
+  before_destroy :assert_no_courses, prepend: true
   
   attr_accessible :default_time_zone, :name
   
@@ -43,7 +43,7 @@ class Organization < ActiveRecord::Base
 protected
 
   def assert_no_courses
-    return if courses.empty?
+    return if courses(true).empty?
     errors.add(:base, "Cannot delete an organization that has courses.")
     false
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -7,7 +7,7 @@ class Section < ActiveRecord::Base
   has_many :students, :dependent => :destroy
   has_many :registration_requests, :dependent => :destroy
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   validates :klass_id, :presence => true
   validates :name, :presence => true, :uniqueness => {:scope => :klass_id}
@@ -47,13 +47,13 @@ protected
 
   def destroyable?
     self.errors.add(:base, "This section cannot be deleted because it is the last one in its course offering") \
-      if klass.sections.count == 1
+      if klass.sections(true).count == 1
     
     self.errors.add(:base, "This section cannot be deleted because students are assigned to it.") \
-      if students.any?
+      if students(true).any?
         
     self.errors.add(:base, "This section cannot be deleted because it has active cohorts.") \
-      if cohorts.any?
+      if cohorts(true).any?
 
     return errors.empty?
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -6,7 +6,7 @@ class Student < ActiveRecord::Base
   belongs_to :cohort
   belongs_to :section
 
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   has_many :student_assignments, :dependent => :destroy
 
   has_one :consent, :as => :consentable, :dependent => :destroy
@@ -144,7 +144,7 @@ class Student < ActiveRecord::Base
 protected
 
   def destroyable?
-    errors.add(:base, "Cannot delete a student who has already started work!") if student_assignments.any?
+    errors.add(:base, "Cannot delete a student who has already started work!") if student_assignments(true).any?
     errors.none?
   end
   

--- a/app/models/student_assignment.rb
+++ b/app/models/student_assignment.rb
@@ -17,7 +17,7 @@ class StudentAssignment < ActiveRecord::Base
   validates :student_id, :presence => true, :uniqueness => {:scope => :assignment_id}
 
   after_create :create_student_exercises
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
 
   # Realized a little late in the game that it is bad when these numbers are the same as
   # the Event enum numbers in student exercise, so made them different

--- a/app/models/student_exercise.rb
+++ b/app/models/student_exercise.rb
@@ -10,7 +10,7 @@ class StudentExercise < ActiveRecord::Base
   has_many :response_times, :as => :response_timeable, :dependent => :destroy
   has_many :free_responses, :dependent => :destroy, :order => :number
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   validates :student_assignment_id, :presence => true
   validates :assignment_exercise_id, :presence => true, 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -8,7 +8,7 @@ class Topic < ActiveRecord::Base
   has_many :assignment_plans, :through => :assignment_plan_topics
   has_many :resources, :order => :number
   
-  before_destroy :destroyable?  
+  before_destroy :destroyable?, prepend: true
   
   validates :learning_plan_id, :presence => true
   validates :name, :presence => true, :uniqueness => {:scope => :learning_plan_id}

--- a/app/models/topic_exercise.rb
+++ b/app/models/topic_exercise.rb
@@ -7,7 +7,7 @@ class TopicExercise < ActiveRecord::Base
   belongs_to :topic
   has_many :assignment_exercises, :dependent => :destroy
   
-  before_destroy :destroyable?
+  before_destroy :destroyable?, prepend: true
   
   validates :topic_id, :presence => true
   # validates :exercise_id, :presence => true, :uniqueness => {:scope => :topic_id}

--- a/lib/acts_as_numberable.rb
+++ b/lib/acts_as_numberable.rb
@@ -81,7 +81,7 @@ module ActsAsNumberable
         # removed from the container), but then when it came time to delete those 
         # objects they still had their old number.  So just reload before
         # destroy.
-        before_destroy {self.reload}
+        before_destroy {self.reload}, prepend: true
       
         after_destroy :remove_from_container!
       


### PR DESCRIPTION
This PR should fix issues #304 and #305 (and possibly others - not sure).

It turns out that `before_destroy` callbacks which refer to class methods are executed after all other callbacks, including the `dependent: :destroy` callbacks on composite model children.  This means that queries in the current model's `destroyanle?` method will return no children, sometime leading to confusion.

To correct this, `prepend: true` has been added to all `before_destroy` callbacks, and refreshed association calls (e.g., `ae.student_exercises(true).any?` have been added inside `destroyable?`-related model methods.
