### PR TITLE
Adds ability to delete APs when sudo_enabled

### DIFF
--- a/app/models/assignment_plan.rb
+++ b/app/models/assignment_plan.rb
@@ -109,7 +109,8 @@ class AssignmentPlan < ActiveRecord::Base
   def self.can_be_assigned; not_assigned.in_progress.where{is_ready == true}; end
   
   def destroyable?
-    errors.add(:base, "This assignment cannot be deleted because it has been assigned") \
+    return true if sudo_enabled?
+    errors.add(:base, "This assignment cannot be deleted because it has been assigned (except by admin override)") \
       if assigned?
     errors.none?
   end

--- a/app/models/assignment_plan_topic.rb
+++ b/app/models/assignment_plan_topic.rb
@@ -17,6 +17,7 @@ class AssignmentPlanTopic < ActiveRecord::Base
     
   
   def destroyable?
+    return true if sudo_enabled?
     self.errors.add(:base, "This topic cannot be removed from its assignment because the assignment has been issued.") \
       if assignment_plan(true).assigned?
     self.errors.none?


### PR DESCRIPTION
This is related to issue #305.

This PR allows an admin to delete an assigned `AssignmentPlan` when `sudo_enabled` is set.
