### PR TITLE
reduces sql queries & detect calls for feedback/presentation conditions from SE

### DIFF
--- a/app/models/learning_condition.rb
+++ b/app/models/learning_condition.rb
@@ -141,11 +141,15 @@ class LearningCondition < ActiveRecord::Base
   end
 
   def get_presentation_condition(student_or_assignment_exercise)
-    get_learning_condition_presentation_condition(student_or_assignment_exercise).presentation_condition
+    student_or_assignment_exercise.is_a?(StudentExercise) ?
+      student_or_assignment_exercise.presentation_condition :
+      get_learning_condition_presentation_condition(student_or_assignment_exercise).presentation_condition
   end
 
   def get_feedback_condition(student_or_assignment_exercise, is_correct=nil)
-    get_learning_condition_feedback_condition(student_or_assignment_exercise, is_correct).feedback_condition
+    student_or_assignment_exercise.is_a?(StudentExercise) ?
+      student_or_assignment_exercise.feedback_condition :
+      get_learning_condition_feedback_condition(student_or_assignment_exercise, is_correct).feedback_condition
   end
 
   def get_learning_condition_presentation_condition(student_or_assignment_exercise)

--- a/app/views/student_exercises/_list.html.erb
+++ b/app/views/student_exercises/_list.html.erb
@@ -14,7 +14,11 @@
   if !local_assigns.has_key?(:student_exercises)
     student_exercise   ||= nil 
     student_assignment ||= student_exercise.student_assignment 
-    student_exercises = student_assignment.student_exercises.joins{assignment_exercise}.order{assignment_exercise.number.asc}
+    student_exercises = student_assignment
+                          .student_exercises
+                          .joins{assignment_exercise}
+                          .order{assignment_exercise.number.asc}
+                          .includes(:assignment_exercise)
   end
 
   show_feedback_status = false if !local_assigns.has_key?(:show_feedback_status)

--- a/db/migrate/20140218235334_add_cached_condition_ids_to_student_exercises.rb
+++ b/db/migrate/20140218235334_add_cached_condition_ids_to_student_exercises.rb
@@ -1,0 +1,9 @@
+class AddCachedConditionIdsToStudentExercises < ActiveRecord::Migration
+  def change
+    add_column :student_exercises, :feedback_condition_id, :integer
+    add_column :student_exercises, :presentation_condition_id, :integer
+
+    add_index :student_exercises, :feedback_condition_id
+    add_index :student_exercises, :presentation_condition_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140107213909) do
+ActiveRecord::Schema.define(:version => 20140218235334) do
 
   create_table "assignment_coworkers", :force => true do |t|
     t.integer  "student_assignment_id"
@@ -494,11 +494,15 @@ ActiveRecord::Schema.define(:version => 20140107213909) do
     t.datetime "exercise_first_viewed_at"
     t.datetime "feedback_first_viewed_at"
     t.integer  "feedback_views_count"
-    t.datetime "feedback_views_timestamp",                    :default => '1980-01-01 20:00:00'
+    t.datetime "feedback_views_timestamp",                    :default => '1980-01-01 17:00:00'
+    t.integer  "feedback_condition_id"
+    t.integer  "presentation_condition_id"
   end
 
   add_index "student_exercises", ["assignment_exercise_id", "student_assignment_id"], :name => "index_ses_on_aes_scoped", :unique => true
   add_index "student_exercises", ["assignment_exercise_id"], :name => "index_student_exercises_on_assignment_exercise_id"
+  add_index "student_exercises", ["feedback_condition_id"], :name => "index_student_exercises_on_feedback_condition_id"
+  add_index "student_exercises", ["presentation_condition_id"], :name => "index_student_exercises_on_presentation_condition_id"
   add_index "student_exercises", ["student_assignment_id"], :name => "index_student_exercises_on_student_assignment_id"
 
   create_table "student_external_assignment_exercises", :force => true do |t|


### PR DESCRIPTION
Note that this PR does not initialize the cached conditions for all SEs, though they should be updated individually as the SEs are saved by students.

We can from the console or other do something like 

`StudentExercise.find_each{|se| se.update_cached_conditions}`

to initialize the cached conditions.  

When reviewing the PR, make sure that we're still getting the feedback and presentation conditions we were previously and that on save the SEs will update their cached references.
