### PR TITLE
Document installation guide for rbenv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ db/.data.yml.gz
 brakeman.html
 cucumber_rerun.txt
 rspec.failures
+.ruby-version
+vendor/cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,9 +100,6 @@ GEM
       xpath (~> 0.1.4)
     capybara-screenshot (0.2.2)
       capybara (>= 1.0)
-    capybara-webkit (0.12.1)
-      capybara (>= 1.0.0, < 1.2)
-      json
     carrierwave (0.7.1)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -204,7 +201,6 @@ GEM
     mini_magick (3.4)
       subexec (~> 0.2.1)
     multi_json (1.8.4)
-    mysql2 (0.3.11)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
     net-sftp (2.0.5)

--- a/doc/rbenv.md
+++ b/doc/rbenv.md
@@ -1,0 +1,96 @@
+# Local installation
+
+This guide enumerates the steps required for getting the ost project
+running locally.  This is a living document and needs to be updated as
+and when things change.
+
+The `rbenv` environment versioning tool is used for managing ruby
+versions.
+
+## Setup rbenv
+
+Follow the [rbenv installation guide][rbenvinstall] to install rbenv.
+
+### Install rbenv plugins
+
+The following plugins are useful for managing ruby and rails projects
+within rbenv.
+
+1. ruby-build: The `rbenv install` command provided by this plugin
+   allows us to install ruby versions through rbenv.  Follow the
+   [ruby-build installation guide][rbbuildinstall].
+2. rbenv-bundler: The `rbenv-bundler` plugin allows bundler commands
+   to be executed directly without the bundler exec prefix.  Follow the
+   [rbenv-bundler installation guide][rbbundlerinstall].
+
+## Fix outdated packages
+
+The OST project as it stands relies on a few outdated packages that
+need to be meddled with before getting a `bundle install` going.
+
+### localtunnel
+
+The localtunnel package has been yanked from the gems repository and
+needs manual installation.  The following commands will make the gem
+available locally.
+
+```
+mkdir vendor/cache
+cd !$
+wget https://rubygems.org/downloads/localtunnel-0.3.gem
+```
+
+### capybara-webkit
+
+>  TODO:  Needs investigation.
+
+This has a dependency on an older `qt` version.  For the time being,
+removing this dependency from the [lock file][] seems to fix the
+installation.  Ideally, depending on a newer version that uses `qt5`
+would be perfect.  However, I am not sure if thats feasible.  So,
+for the time being, I proceeded with the installtion by yanking this
+out of the lockfile.
+
+## Install major dependencies
+
+Now that the misbehaving packages are out of the way, we can proceed
+towards a good `bundle install`.
+
+```
+### Install ruby
+rbenv install 1.9.3-p194
+rbenv rehash
+rbenv global 1.9.3-p194
+
+### At this point, it seems like a good idea to relaunch the terminal.
+gem install rake:10.1.1
+gem install bundler
+rbenv rehash
+```
+
+## Bundle install
+
+Now we are ready for installing the requirements for the OST project.
+
+```
+bundle --without production
+rbenv rehash
+```
+
+# Running OST
+
+Since we have the bundler plugin for rbenv, we don't need to call `bundle exec`.
+
+The following commands should get us up and running:
+
+```
+rake db:migrate
+rails server
+```
+
+Ensure everything is up and running by launching <http://localhost:3000>.
+
+[rbenvinstall]: https://github.com/sstephenson/rbenv#installation
+[rbbuildinstall]: https://github.com/sstephenson/ruby-build#installation
+[rbbundlerinstall]: https://github.com/carsomyr/rbenv-bundler#installation
+[lock file]: https://github.com/lml/ost/blob/master/Gemfile.lock#L103


### PR DESCRIPTION
This probably doesn't need to be merged as is. Perhaps the installation guide can be merged to the Readme.  Just for review and feedback.

---
- Add rbenv.md with steps for getting OST up and running with rbenv.
- Remove `capybara-webkit` from Gemfile.lock temporarily.
- Add `vendor/cache` and `.ruby-version` to .gitignore.
