### PR TITLE
lml/ost#340: Add exercise content(question) to the feedback page.

### DIFF
--- a/app/views/student_exercises/feedback.html.erb
+++ b/app/views/student_exercises/feedback.html.erb
@@ -1,25 +1,31 @@
-<%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
+<%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<%= pageHeading("Feedback on #{@student_exercise.assignment.assignment_plan.name}, " + 
-                "Exercise #{@student_exercise.assignment_exercise.number}", 
+<%= pageHeading("Feedback on #{@student_exercise.assignment.assignment_plan.name}, " +
+                "Exercise #{@student_exercise.assignment_exercise.number}",
                 {:sub_heading_text => @student_exercise.student_assignment.student.section.klass.name})%>
 <% learning_condition = @student_exercise.learning_condition %>
 
 <% if true %>
-  <%= render :partial => "student_answer", :locals => { :student_exercise => @student_exercise } %> 
-<% end %>
-
-<% if learning_condition.show_correctness_feedback?(@student_exercise) %>
-  <%= render :partial => "correctness_feedback", :locals => { :student_exercise => @student_exercise } %> 
-<% end %>
-
-<% if learning_condition.show_correct_answer_feedback?(@student_exercise) %>
-  <%= render :partial => "correct_answer_feedback", :locals => { :student_exercise => @student_exercise } %> 
+  <%= section "Exercise", {:classes => 'first no_bar', :collapsible => true, :collapsed => true} do %>
+    <%= render "question", student_exercise: @student_exercise %>
+  <% end %>
 <% end %>
 
 <% if true %>
-  <%= render :partial => "solution_feedback", :locals => { :student_exercise => @student_exercise } %> 
+  <%= render :partial => "student_answer", :locals => { :student_exercise => @student_exercise } %>
+<% end %>
+
+<% if learning_condition.show_correctness_feedback?(@student_exercise) %>
+  <%= render :partial => "correctness_feedback", :locals => { :student_exercise => @student_exercise } %>
+<% end %>
+
+<% if learning_condition.show_correct_answer_feedback?(@student_exercise) %>
+  <%= render :partial => "correct_answer_feedback", :locals => { :student_exercise => @student_exercise } %>
+<% end %>
+
+<% if true %>
+  <%= render :partial => "solution_feedback", :locals => { :student_exercise => @student_exercise } %>
 <% end %>
 
 <%= render :partial => 'shared/response_times',

--- a/app/views/student_exercises/show.html.erb
+++ b/app/views/student_exercises/show.html.erb
@@ -1,4 +1,4 @@
-<%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
+<%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 <% read_errors(@student_exercise) %>
@@ -10,7 +10,7 @@
 <% if @student_exercise.present_free_response_and_selected_answer? %>
 
   <%= section "Your Answer", {:classes => 'no_bar'} do %>
-    
+
     <%= render 'free_response_list', student_exercise: @student_exercise %>
     <% if @student_exercise.free_responses_can_be_updated? %>
       <%= render 'add_and_turn_in_free_responses', student_exercise: @student_exercise %>
@@ -37,7 +37,7 @@
       <%= render "show_selected_answer", student_exercise: @student_exercise %>
     <% else %>
       <%= render "input_selected_answer", student_exercise: @student_exercise %>
-    <% end %>  
+    <% end %>
   <% end %>
 
 <% else %>
@@ -51,7 +51,7 @@
     function preview_text_free_response(form_id) {
       $.get('<%= preview_text_free_responses_path %>', $('#' + form_id).serializeArray());
 
-      <% if Ost::Application.config.enable_response_times %>    
+      <% if Ost::Application.config.enable_response_times %>
         mark_time('ACTIVITY','preview');
       <% end %>
     }


### PR DESCRIPTION
WIP.
- Add exercise content (question only) to the feedback page as a
  collapsible section.
- Remove trailing whitespaces.
- Remote trailing whitespaces in `show.html.erb` as well.

Notes:
- Free text/drawing provided by the student is not shown.
- The other options in multiple selection are not shown.
- The sidebar nav has misleading text ("Show" instead of "Go to")
- Collapsible sections could use simple CSS instead of inline JS.
- By introducing a section heading the header hierarchy is disrupted.
