### PR TITLE
Fix feedback penalty default value.

### DIFF
--- a/app/assets/javascripts/learning_conditions.js.coffee
+++ b/app/assets/javascripts/learning_conditions.js.coffee
@@ -13,5 +13,5 @@ $ () ->
       feedbackPenaltyValue.val "100"
       feedbackPenalty.show()
     else
-      feedbackPenaltyValue.val null
+      feedbackPenaltyValue.val 0
       feedbackPenalty.hide()

--- a/app/models/feedback_condition.rb
+++ b/app/models/feedback_condition.rb
@@ -272,7 +272,7 @@ protected
     self.label_regex                     ||= '.*'
     self.exercise_correctness_option     ||= ExerciseCorrectnessOption::ANY_CORRECTNESS
     self.is_feedback_required_for_credit ||= false
-    self.feedback_viewing_penalty        ||= 0
+    self.feedback_viewing_penalty        ||= self.is_feedback_required_for_credit ? 100 : 0
     self.availability_opens_option       ||= AvailabilityOpensOption::NEVER
     self.availability_closes_option      ||= AvailabilityClosesOption::NEVER
     self.availability_event              ||= AvailabilityEvent::NOT_APPLICABLE

--- a/app/views/feedback_conditions/_form_fields.html.erb
+++ b/app/views/feedback_conditions/_form_fields.html.erb
@@ -30,7 +30,7 @@
   <%= link_to_help 'feedback_viewing_penalty',
       text="Penalty",
       {:title => 'Penalty'} %> if a student does not view feedback (0-100%):
-  <%= form.number_field :feedback_viewing_penalty, in:0..100, step:1, size:3, value: 100 %>
+  <%= form.number_field :feedback_viewing_penalty, in:0..100, step:1, size:3 %>
 </div>
 <div class="field">
   <%= form.check_box :can_automatically_show_feedback %>

--- a/app/views/feedback_conditions/_show.html.erb
+++ b/app/views/feedback_conditions/_show.html.erb
@@ -7,7 +7,9 @@
   <li>Matches labels against: <%= feedback_condition.label_regex || "[Not set]" %></li>
   <li>Matches correctness against: <%= FeedbackCondition::ExerciseCorrectnessOption[feedback_condition.exercise_correctness_option].to_s.humanize %></li>
   <li>Feedback viewing is required?: <%= tf_to_yn(feedback_condition.is_feedback_required_for_credit) %></li>
+  <% if feedback_condition.is_feedback_required_for_credit %>
   <li>Feedback viewing penalty: <%= feedback_condition.feedback_viewing_penalty || 0 %>%</li>
+  <% end %>
   <li>Can automatically show feedback?: <%= tf_to_yn(feedback_condition.can_automatically_show_feedback) %></li>
   <li>Feedback becomes available: 
     <%= 


### PR DESCRIPTION
Currently, the production servers do not have the feedback penalty
column.  When this gets merged and deployed to production, the
records that have feedback_viewing_required must default the penalty
to 100.
- Add conditional default value for feedback penalty
- Hide the feedback penalty line item in the show view
  when the feedback need not be viewed
- When feedback penalty is not required, set the penalty value
  to 0 in Javascript to be consistent - since `null` value has
  an overloaded meaning.

[Finishes #77591162]

https://www.pivotaltracker.com/n/projects/1144352/stories/77591162
